### PR TITLE
Swap2

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
     "prettier/prettier": "error",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "react/prop-types": "off"
   }
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react'
 import { Route, Switch, Redirect } from 'react-router-dom'
 import { ChainId } from '@sushiswap/sdk'
-import { useActiveWeb3React } from '../hooks/index'
+import { useActiveWeb3React } from '../hooks'
 import styled from 'styled-components'
 import GoogleAnalyticsReporter from '../components/analytics/GoogleAnalyticsReporter'
 
@@ -30,6 +30,7 @@ import PoolFinder from './PoolFinder'
 import RemoveLiquidity from './RemoveLiquidity'
 import { RedirectOldRemoveLiquidityPathStructure } from './RemoveLiquidity/redirects'
 import Swap from './Swap'
+import Swap2 from '../prototype/pages/Swap2'
 import { OpenClaimAddressModalAndRedirectToSwap, RedirectPathToSwapOnly, RedirectToSwap } from './Swap/redirects'
 //import Vote from './Vote'
 //import VotePage from './Vote/VotePage'
@@ -110,6 +111,7 @@ export default function App() {
               <Route exact path="/sushibar" render={() => <Redirect to="/stake" />} />
               {/* Pages */}
               <Route exact strict path="/swap" component={Swap} />
+              <Route exact strict path="/swap2" component={Swap2} />
               <Route exact strict path="/claim" component={OpenClaimAddressModalAndRedirectToSwap} />
               <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
               <Route exact strict path="/send" component={RedirectPathToSwapOnly} />

--- a/src/prototype/AppBody.tsx
+++ b/src/prototype/AppBody.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import styled from 'styled-components'
+
+export const BodyWrapper = styled.div`
+  position: relative;
+  max-width: 480px;
+  width: 100%;
+  background: ${({ theme }) => theme.bg1};
+  box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.01), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
+    0px 24px 32px rgba(0, 0, 0, 0.01);
+  border-radius: 20px;
+  /* padding: 1rem; */
+`
+
+/**
+ * The styled container element that wraps the content of most pages and the tabs.
+ */
+export default function AppBody({ children }: { children: React.ReactNode }) {
+  return <BodyWrapper>{children}</BodyWrapper>
+}

--- a/src/prototype/components/Button/index.tsx
+++ b/src/prototype/components/Button/index.tsx
@@ -1,0 +1,313 @@
+import React from 'react'
+import styled, { keyframes } from 'styled-components'
+import { darken, lighten } from 'polished'
+
+import { RowBetween } from 'components/Row'
+import { ChevronDown } from 'react-feather'
+import { Button as RebassButton, ButtonProps } from 'rebass/styled-components'
+
+const Base = styled(RebassButton)<{
+  padding?: string
+  width?: string
+  borderRadius?: string
+  altDisabledStyle?: boolean
+}>`
+  padding: ${({ padding }) => (padding ? padding : '12px')};
+  width: ${({ width }) => (width ? width : '100%')};
+  font-weight: 500;
+  text-align: center;
+  border-radius: ${({ theme }) => theme.borderRadius};
+  outline: none;
+  border: 1px solid transparent;
+  color: white;
+  text-decoration: none;
+  display: flex;
+  justify-content: center;
+  flex-wrap: nowrap;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  &:disabled {
+    cursor: auto;
+  }
+
+  > * {
+    user-select: none;
+  }
+`
+
+const sheen = keyframes`{
+  100% {
+    transform: rotateZ(60deg) translate(1em, -23em);
+  }
+}`
+
+export const ButtonPrimary = styled(Base)`
+  /* background-color: ${({ theme }) => theme.primary1}; */
+  overflow:hidden;
+  background: linear-gradient(to right, #0094ec , #f537c3);
+  background-origin: border-box;
+  color: white;
+  &:focus {
+    box-shadow: 0 0 0 1pt ${({ theme }) => darken(0.05, theme.primary1)};
+    /*background: ${({ theme }) => darken(0.05, theme.primary1)};*/
+    background: linear-gradient(to right, #0094ec , #f537c3);
+  }
+  &:active {
+    box-shadow: 0 0 0 1pt ${({ theme }) => darken(0.1, theme.primary1)};
+    /*background: ${({ theme }) => darken(0.1, theme.primary1)};*/
+    background: linear-gradient(to right, #0094ec , #f537c3);
+  }
+  &:disabled {
+    pointer-events: none;
+    background: ${({ theme, altDisabledStyle, disabled }) =>
+      altDisabledStyle ? (disabled ? theme.bg3 : theme.primary1) : theme.bg3};
+    color: ${({ theme, altDisabledStyle, disabled }) =>
+      altDisabledStyle ? (disabled ? theme.text3 : 'white') : theme.text3};
+    cursor: auto;
+    box-shadow: none;
+    border: 1px solid transparent;
+    outline: none;
+    opacity: ${({ altDisabledStyle }) => (altDisabledStyle ? '0.5' : '1')};
+  }
+  &:hover {
+    /*background: ${({ theme }) => darken(0.05, theme.primary1)};*/
+    background: linear-gradient(to right, #0094ec , #f537c3);
+    background-origin: border-box;
+    &::after {
+      animation: ${sheen} 0.5s forwards;
+    }
+  }
+  
+  &::after {
+    content: '';
+    position: absolute;
+    top: -50%;
+    right: -50%;
+    bottom: -50%;
+    left: -120%;
+    background: linear-gradient(to bottom, rgba(229, 172, 142, 0), rgba(255,255,255,0.5) 50%, rgba(229, 172, 142, 0));
+    transform: rotateZ(60deg) translate(-5em, 7.5em);
+  }
+`
+
+export const ButtonPrimaryNormal = styled(Base)`
+  background-color: ${({ theme }) => theme.primary1};
+  color: white;
+  &:focus {
+    box-shadow: 0 0 0 1pt ${({ theme }) => darken(0.05, theme.primary1)};
+    background-color: ${({ theme }) => darken(0.05, theme.primary1)};
+  }
+  &:hover {
+    background-color: ${({ theme }) => darken(0.05, theme.primary1)};
+  }
+  &:active {
+    box-shadow: 0 0 0 1pt ${({ theme }) => darken(0.1, theme.primary1)};
+    background-color: ${({ theme }) => darken(0.1, theme.primary1)};
+  }
+  &:disabled {
+    background-color: ${({ theme, altDisabledStyle, disabled }) =>
+      altDisabledStyle ? (disabled ? theme.bg3 : theme.primary1) : theme.bg3};
+    color: ${({ theme, altDisabledStyle, disabled }) =>
+      altDisabledStyle ? (disabled ? theme.text3 : 'white') : theme.text3};
+    cursor: auto;
+    box-shadow: none;
+    border: 1px solid transparent;
+    outline: none;
+    opacity: ${({ altDisabledStyle }) => (altDisabledStyle ? '0.5' : '1')};
+  }
+`
+
+export const ButtonLight = styled(Base)`
+  background-color: ${({ theme }) => theme.primary5};
+  color: ${({ theme }) => theme.primaryText1};
+  font-size: 16px;
+  font-weight: 500;
+  &:focus {
+    box-shadow: 0 0 0 1pt ${({ theme, disabled }) => !disabled && darken(0.03, theme.primary5)};
+    background-color: ${({ theme, disabled }) => !disabled && darken(0.03, theme.primary5)};
+  }
+  &:hover {
+    background-color: ${({ theme, disabled }) => !disabled && darken(0.03, theme.primary5)};
+  }
+  &:active {
+    box-shadow: 0 0 0 1pt ${({ theme, disabled }) => !disabled && darken(0.05, theme.primary5)};
+    background-color: ${({ theme, disabled }) => !disabled && darken(0.05, theme.primary5)};
+  }
+  :disabled {
+    opacity: 0.4;
+    :hover {
+      cursor: auto;
+      background-color: ${({ theme }) => theme.primary5};
+      box-shadow: none;
+      border: 1px solid transparent;
+      outline: none;
+    }
+  }
+`
+
+export const ButtonGray = styled(Base)`
+  background-color: ${({ theme }) => theme.bg3};
+  color: ${({ theme }) => theme.text2};
+  font-size: 16px;
+  font-weight: 500;
+  &:focus {
+    background-color: ${({ theme, disabled }) => !disabled && darken(0.05, theme.bg4)};
+  }
+  &:hover {
+    background-color: ${({ theme, disabled }) => !disabled && darken(0.05, theme.bg4)};
+  }
+  &:active {
+    background-color: ${({ theme, disabled }) => !disabled && darken(0.1, theme.bg4)};
+  }
+`
+
+export const ButtonUNIGradient = styled(ButtonPrimary)`
+  color: white;
+  padding: 4px 8px;
+  height: 36px;
+  font-weight: 500;
+  background-color: ${({ theme }) => theme.bg3};
+  background: radial-gradient(174.47% 188.91% at 1.84% 0%, #ff007a 0%, #0094ec 100%), #edeef2;
+  width: fit-content;
+  position: relative;
+  cursor: pointer;
+  border: none;
+  white-space: no-wrap;
+  :hover {
+    opacity: 0.8;
+  }
+  :active {
+    opacity: 0.9;
+  }
+`
+
+export const ButtonOutlined = styled(Base)`
+  border: 1px solid ${({ theme }) => theme.bg2};
+  background-color: transparent;
+  color: ${({ theme }) => theme.text1};
+
+  &:focus {
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.bg4};
+  }
+  &:hover {
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.bg4};
+  }
+  &:active {
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.bg4};
+  }
+  &:disabled {
+    opacity: 50%;
+    cursor: auto;
+  }
+`
+
+export const ButtonEmpty = styled(Base)`
+  background-color: transparent;
+  color: ${({ theme }) => theme.primary1};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &:focus {
+    text-decoration: underline;
+  }
+  &:hover {
+    text-decoration: none;
+  }
+  &:active {
+    text-decoration: none;
+  }
+  &:disabled {
+    opacity: 50%;
+    cursor: auto;
+  }
+`
+
+export const ButtonWhite = styled(Base)`
+  border: 1px solid #edeef2;
+  background-color: ${({ theme }) => theme.bg1};
+  color: black;
+
+  &:focus {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    box-shadow: 0 0 0 1pt ${darken(0.05, '#edeef2')};
+  }
+  &:hover {
+    box-shadow: 0 0 0 1pt ${darken(0.1, '#edeef2')};
+  }
+  &:active {
+    box-shadow: 0 0 0 1pt ${darken(0.1, '#edeef2')};
+  }
+  &:disabled {
+    opacity: 50%;
+    cursor: auto;
+  }
+`
+
+const ButtonConfirmedStyle = styled(Base)`
+  background-color: ${({ theme }) => lighten(0.5, theme.green1)};
+  color: ${({ theme }) => theme.green1};
+  border: 1px solid ${({ theme }) => theme.green1};
+
+  &:disabled {
+    opacity: 50%;
+    cursor: auto;
+  }
+`
+
+const ButtonErrorStyle = styled(Base)`
+  background-color: ${({ theme }) => theme.red1};
+  border: 1px solid ${({ theme }) => theme.red1};
+
+  &:focus {
+    box-shadow: 0 0 0 1pt ${({ theme }) => darken(0.05, theme.red1)};
+    background-color: ${({ theme }) => darken(0.05, theme.red1)};
+  }
+  &:hover {
+    background-color: ${({ theme }) => darken(0.05, theme.red1)};
+  }
+  &:active {
+    box-shadow: 0 0 0 1pt ${({ theme }) => darken(0.1, theme.red1)};
+    background-color: ${({ theme }) => darken(0.1, theme.red1)};
+  }
+  &:disabled {
+    opacity: 50%;
+    cursor: auto;
+    box-shadow: none;
+    background-color: ${({ theme }) => theme.red1};
+    border: 1px solid ${({ theme }) => theme.red1};
+  }
+`
+
+export function ButtonConfirmed({
+  confirmed,
+  altDisabledStyle,
+  ...rest
+}: { confirmed?: boolean; altDisabledStyle?: boolean } & ButtonProps) {
+  if (confirmed) {
+    return <ButtonConfirmedStyle {...rest} />
+  } else {
+    return <ButtonPrimary {...rest} altDisabledStyle={altDisabledStyle} />
+  }
+}
+
+export function ButtonError({ error, ...rest }: { error?: boolean } & ButtonProps) {
+  if (error) {
+    return <ButtonErrorStyle {...rest} />
+  } else {
+    return <ButtonPrimary {...rest} />
+  }
+}
+
+export function ButtonDropdownGrey({ disabled = false, children, ...rest }: { disabled?: boolean } & ButtonProps) {
+  return (
+    <ButtonGray {...rest} disabled={disabled} style={{ borderRadius: '20px' }}>
+      <RowBetween>
+        <div style={{ display: 'flex', alignItems: 'center' }}>{children}</div>
+        <ChevronDown size={24} />
+      </RowBetween>
+    </ButtonGray>
+  )
+}

--- a/src/prototype/components/CurrencyInputPanel/index.tsx
+++ b/src/prototype/components/CurrencyInputPanel/index.tsx
@@ -1,0 +1,335 @@
+import { Currency, Pair } from '@sushiswap/sdk'
+import React, { FC, useCallback, useState } from 'react'
+import styled from 'styled-components'
+import { lighten, transparentize } from 'polished'
+import { useCurrencyBalance } from '../../../state/wallet/hooks'
+import CurrencySearchModal from 'components/SearchModal/CurrencySearchModal'
+import CurrencyLogo from 'components/CurrencyLogo'
+import DoubleCurrencyLogo from 'components/DoubleLogo'
+import { AutoRow, RowFixed } from 'components/Row'
+import { TYPE } from '../../../theme'
+import { Input as NumericalInput } from 'components/NumericalInput'
+import { ReactComponent as DropDown } from '../../../assets/images/dropdown.svg'
+
+import { useActiveWeb3React } from '../../../hooks'
+import { useTranslation } from 'react-i18next'
+import useTheme from '../../../hooks/useTheme'
+import { Lock } from 'react-feather'
+import { AutoColumn } from 'components/Column'
+
+const InputRow = styled.div<{ selected: boolean }>`
+  ${({ theme }) => theme.flexRowNoWrap}
+  align-items: center;
+  padding: 0;
+`
+
+const CurrencySelect = styled.button<{ selected: boolean; isInputPanel?: boolean }>`
+  align-items: center;
+  height: 1.8rem;
+  font-size: 16px;
+  font-weight: 600;
+  background-color: ${({ theme }) => theme.bg1};
+  color: ${({ isInputPanel, theme }) => (isInputPanel ? theme.secondary1 : theme.secondary2)};
+  border-radius: 25px;
+  box-shadow: ${({ selected }) => (selected ? 'none' : '0px 6px 10px rgba(0, 0, 0, 0.075)')};
+  outline: none;
+  cursor: pointer;
+  user-select: none;
+  border: none;
+
+  :focus,
+  :hover {
+    background-color: ${({ theme }) => lighten(0.05, theme.bg1)};
+  }
+`
+
+const Aligner = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`
+
+const StyledDropDown = styled(DropDown)<{ isInputPanel?: boolean }>`
+  margin: 0 0.25rem 0 0.5rem;
+  height: 35%;
+
+  path {
+    stroke: ${({ isInputPanel, theme }) => (isInputPanel ? theme.secondary1 : theme.secondary2)};
+    stroke-width: 1.5px;
+  }
+`
+
+const InputPanel = styled.div<{ hideInput?: boolean }>`
+  ${({ theme }) => theme.flexColumnNoWrap}
+  position: relative;
+  border-radius: ${({ hideInput }) => (hideInput ? '8px' : '20px')};
+  background-color: ${({ theme }) => theme.bg2};
+  z-index: 1;
+`
+
+const Container = styled.div<{
+  hideInput: boolean
+  cornerRadiusTopNone?: boolean
+  cornerRadiusBottomNone?: boolean
+  containerBackground?: string
+}>`
+  border-radius: ${({ hideInput }) => (hideInput ? '8px' : '12px')};
+  border-radius: ${({ cornerRadiusTopNone }) => cornerRadiusTopNone && '0 0 12px 12px'};
+  border-radius: ${({ cornerRadiusBottomNone }) => cornerRadiusBottomNone && '12px 12px 0 0'};
+  background-color: ${({ theme }) => theme.bg2};
+  background-color: ${({ containerBackground }) => containerBackground};
+`
+
+const StyledTokenName = styled.span<{ active?: boolean }>`
+  white-space: nowrap;
+  margin: 0 0.25rem 0 0.4rem;
+  font-size: 16px;
+`
+
+const StyledBalanceMax = styled.button`
+  height: 1.8rem;
+  padding-right: 8px;
+  padding-left: 8px;
+  background-color: ${({ theme }) => theme.bg1};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-right: 0.5rem;
+  color: ${({ theme }) => theme.text1};
+  border: none;
+
+  :hover {
+    background-color: ${({ theme }) => lighten(0.05, theme.bg1)};
+  }
+  :focus {
+    border: 1px solid ${({ theme }) => theme.primary1};
+    outline: none;
+  }
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    margin-right: 0.5rem;
+  `};
+`
+
+const IconWrapper = styled.div`
+  background: ${({ theme }) => theme.bg1};
+  width: 56px;
+  height: 56px;
+  justify-content: center;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+`
+
+const StyledLockIconWrapper = styled.div`
+  background: ${({ theme }) => transparentize(0.9, theme.secondary2)};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  margin-left: 12px;
+  width: 52px;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  :hover {
+    background-color: ${({ theme }) => transparentize(0.7, theme.secondary2)};
+  }
+`
+
+const StyledLockIcon = styled(Lock)`
+  height: 20px;
+  width: 20px;
+
+  > * {
+    stroke: ${({ theme }) => theme.secondary2};
+  }
+`
+
+interface CurrencyInputPanelProps {
+  value: string
+  onUserInput: (value: string) => void
+  onMax?: () => void
+  showMaxButton: boolean
+  label?: string
+  onCurrencySelect?: (currency: Currency) => void
+  currency?: Currency | null
+  disableCurrencySelect?: boolean
+  hideBalance?: boolean
+  pair?: Pair | null
+  hideInput?: boolean
+  otherCurrency?: Currency | null
+  id: string
+  showCommonBases?: boolean
+  customBalanceText?: string
+  cornerRadiusBottomNone?: boolean
+  cornerRadiusTopNone?: boolean
+  isInputPanel?: boolean
+}
+
+const CurrencyInputPanel: FC<CurrencyInputPanelProps> = ({
+  children,
+  value,
+  onUserInput,
+  onMax,
+  showMaxButton,
+  label = 'Input',
+  onCurrencySelect,
+  currency,
+  disableCurrencySelect = false,
+  hideBalance = false,
+  pair = null, // used for double token logo
+  hideInput = false,
+  otherCurrency,
+  id,
+  showCommonBases,
+  customBalanceText,
+  cornerRadiusBottomNone = false,
+  cornerRadiusTopNone = false,
+  isInputPanel
+}) => {
+  const { t } = useTranslation()
+
+  const [modalOpen, setModalOpen] = useState(false)
+  const { account, chainId } = useActiveWeb3React()
+  const selectedCurrencyBalance = useCurrencyBalance(account ?? undefined, currency ?? undefined)
+  const theme = useTheme()
+
+  const handleDismissSearch = useCallback(() => {
+    setModalOpen(false)
+  }, [setModalOpen])
+
+  return (
+    <InputPanel id={id}>
+      <Container
+        hideInput={hideInput}
+        cornerRadiusBottomNone={cornerRadiusBottomNone}
+        cornerRadiusTopNone={cornerRadiusTopNone}
+      >
+        <AutoColumn style={{ padding: '14px 8px' }} gap="4px">
+          <AutoRow gap="4px" justify="space-between">
+            <AutoRow style={{ display: 'inline-flex', width: 'unset' }} gap="4px">
+              <RowFixed>
+                <IconWrapper>
+                  {pair ? (
+                    <DoubleCurrencyLogo currency0={pair.token0} currency1={pair.token1} size={42} margin={true} />
+                  ) : currency ? (
+                    <CurrencyLogo currency={currency} size="42px" />
+                  ) : null}
+                </IconWrapper>
+              </RowFixed>
+              <AutoColumn>
+                <AutoRow gap="4px" style={{ flexWrap: 'nowrap' }}>
+                  <CurrencySelect
+                    isInputPanel={isInputPanel}
+                    selected={!!currency}
+                    className="open-currency-select-button"
+                    onClick={() => {
+                      if (!disableCurrencySelect) {
+                        setModalOpen(true)
+                      }
+                    }}
+                  >
+                    <Aligner>
+                      {pair ? (
+                        <StyledTokenName className="pair-name-container">
+                          {pair?.token0.symbol}:{pair?.token1.symbol}
+                        </StyledTokenName>
+                      ) : (
+                        <StyledTokenName
+                          className="token-symbol-container"
+                          active={Boolean(currency && currency.symbol)}
+                        >
+                          {(currency && currency.symbol && currency.symbol.length > 20
+                            ? currency.symbol.slice(0, 4) +
+                              '...' +
+                              currency.symbol.slice(currency.symbol.length - 5, currency.symbol.length)
+                            : currency?.getSymbol(chainId)) || t('selectToken')}
+                        </StyledTokenName>
+                      )}
+                      {!disableCurrencySelect && <StyledDropDown isInputPanel={isInputPanel} />}
+                    </Aligner>
+                  </CurrencySelect>
+                  {account && currency && showMaxButton && label !== 'To' && (
+                    <StyledBalanceMax onClick={onMax}>MAX</StyledBalanceMax>
+                  )}
+                </AutoRow>
+                {account && (
+                  <AutoRow>
+                    <TYPE.body
+                      onClick={onMax}
+                      color={theme.text3}
+                      fontSize=".875rem"
+                      fontWeight={500}
+                      style={{ display: 'inline', cursor: 'pointer', marginTop: 8, marginLeft: 2 }}
+                    >
+                      {!hideBalance && !!currency && selectedCurrencyBalance ? (
+                        <>
+                          {customBalanceText ?? 'Balance '}
+                          <TYPE.body fontSize=".875rem" fontWeight={600} display="inline" color={theme.text3}>
+                            {selectedCurrencyBalance?.toSignificant(6)}
+                          </TYPE.body>
+                        </>
+                      ) : (
+                        ' -'
+                      )}
+                    </TYPE.body>
+                  </AutoRow>
+                )}
+              </AutoColumn>
+            </AutoRow>
+            <InputRow
+              style={hideInput ? { padding: '0', borderRadius: '8px', flex: 1 } : { flex: 1 }}
+              selected={disableCurrencySelect}
+            >
+              {!hideInput && (
+                <AutoColumn style={{ flex: '1' }}>
+                  <AutoRow justify="flex-end">
+                    <TYPE.body color={theme.text3} fontWeight="bold" fontSize=".875rem" display="inline">
+                      {!isInputPanel && '~'} $3,243.52{' '}
+                      {!isInputPanel && (
+                        <TYPE.body color={theme.secondary2} fontWeight="bold" fontSize=".875rem" display="inline">
+                          (-5.4%)
+                        </TYPE.body>
+                      )}
+                    </TYPE.body>
+                  </AutoRow>
+                  <AutoRow style={{ marginTop: 6 }}>
+                    <NumericalInput
+                      align="right"
+                      className="token-amount-input"
+                      value={value}
+                      onUserInput={val => {
+                        onUserInput(val)
+                      }}
+                      style={{ top: 4 }}
+                    />
+                  </AutoRow>
+                </AutoColumn>
+              )}
+              {isInputPanel && (
+                <StyledLockIconWrapper>
+                  <StyledLockIcon size="24" />
+                </StyledLockIconWrapper>
+              )}
+            </InputRow>
+          </AutoRow>
+        </AutoColumn>
+      </Container>
+      {children}
+      {!disableCurrencySelect && onCurrencySelect && (
+        <CurrencySearchModal
+          isOpen={modalOpen}
+          onDismiss={handleDismissSearch}
+          onCurrencySelect={onCurrencySelect}
+          selectedCurrency={currency}
+          otherSelectedCurrency={otherCurrency}
+          showCommonBases={showCommonBases}
+        />
+      )}
+    </InputPanel>
+  )
+}
+
+export default CurrencyInputPanel

--- a/src/prototype/components/CurrencyInputPanelSwitch/index.tsx
+++ b/src/prototype/components/CurrencyInputPanelSwitch/index.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledArrowIcon = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50px;
+  background-color: ${({ theme }) => theme.bg2};
+  border: 3px solid ${({ theme }) => theme.bg1};
+  padding: 6px;
+  width: 36px;
+  height: 36px;
+`
+
+const ArrowsIcon = () => {
+  return (
+    <svg
+      style={{ height: '1.4rem', margin: '0 auto' }}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"
+      />
+    </svg>
+  )
+}
+
+interface CurrencyInputPanelSwitchProps {
+  setApprovalSubmitted: (approval: boolean) => void
+  onSwitchTokens: () => void
+}
+
+const CurrencyInputPanelSwitch = ({ setApprovalSubmitted, onSwitchTokens }: CurrencyInputPanelSwitchProps) => {
+  return (
+    <div style={{ position: 'relative', zIndex: 2, height: 12 }}>
+      <div
+        style={{
+          position: 'absolute',
+          width: '100%',
+          cursor: 'pointer',
+          marginTop: '-12px',
+          display: 'flex',
+          justifyContent: 'center'
+        }}
+        onClick={() => {
+          setApprovalSubmitted(false) // reset 2 step UI for approvals
+          onSwitchTokens()
+        }}
+      >
+        <StyledArrowIcon>
+          <ArrowsIcon />
+        </StyledArrowIcon>
+      </div>
+    </div>
+  )
+}
+
+export default CurrencyInputPanelSwitch

--- a/src/prototype/components/GasIconButton/index.tsx
+++ b/src/prototype/components/GasIconButton/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { StyledMenuButton } from '../StyledMenu'
+import styled from 'styled-components'
+import { TYPE } from 'theme'
+import useTheme from '../../../hooks/useTheme'
+
+const StyledGasIcon = styled.span`
+  color: ${({ theme }) => theme.green1};
+  > * {
+    stroke: ${({ theme }) => theme.green1};
+  }
+
+  :hover {
+    opacity: 0.7;
+  }
+`
+
+const GasIconButton = () => {
+  const theme = useTheme()
+
+  return (
+    <StyledMenuButton style={{ display: 'flex', alignItems: 'center' }}>
+      <StyledGasIcon>
+        <svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" style={{ height: 22, width: 22 }}>
+          <path d="M19.77 7.23l.01-.01-3.72-3.72L15 4.56l2.11 2.11c-.94.36-1.61 1.26-1.61 2.33 0 1.38 1.12 2.5 2.5 2.5.36 0 .69-.08 1-.21v7.21c0 .55-.45 1-1 1s-1-.45-1-1V14c0-1.1-.9-2-2-2h-1V5c0-1.1-.9-2-2-2H6c-1.1 0-2 .9-2 2v16h10v-7.5h1.5v5c0 1.38 1.12 2.5 2.5 2.5s2.5-1.12 2.5-2.5V9c0-.69-.28-1.32-.73-1.77zM12 13.5V19H6v-7h6v1.5zm0-3.5H6V5h6v5zm6 0c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1z"></path>{' '}
+        </svg>
+      </StyledGasIcon>
+      <TYPE.body fontWeight={600} color={theme.green1} display="inline" style={{ marginLeft: '2px' }}>
+        26
+      </TYPE.body>
+    </StyledMenuButton>
+  )
+}
+
+export default GasIconButton

--- a/src/prototype/components/RefreshButton/index.tsx
+++ b/src/prototype/components/RefreshButton/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { StyledMenuButton } from '../StyledMenu'
+import styled from 'styled-components'
+import { RefreshCw } from 'react-feather'
+
+const StyledRefreshIcon = styled(RefreshCw)`
+  height: 16px;
+  width: 16px;
+
+  > * {
+    stroke: ${({ theme }) => theme.text3};
+  }
+
+  :hover {
+    opacity: 0.7;
+  }
+`
+
+const RefreshButton = () => {
+  return (
+    <div style={{ marginLeft: '0.5rem' }}>
+      <StyledMenuButton>
+        <StyledRefreshIcon strokeWidth={3} />
+      </StyledMenuButton>
+    </div>
+  )
+}
+
+export default RefreshButton

--- a/src/prototype/components/Settings/index.tsx
+++ b/src/prototype/components/Settings/index.tsx
@@ -1,0 +1,204 @@
+import React, { useContext, useRef, useState } from 'react'
+import { Sliders, X } from 'react-feather'
+import { Text } from 'rebass'
+import styled, { ThemeContext } from 'styled-components'
+import { useOnClickOutside } from '../../../hooks/useOnClickOutside'
+import { ApplicationModal } from '../../../state/application/actions'
+import { useModalOpen, useToggleSettingsMenu } from '../../../state/application/hooks'
+import {
+  useExpertModeManager,
+  useUserTransactionTTL,
+  useUserSlippageTolerance,
+  useUserSingleHopOnly
+} from '../../../state/user/hooks'
+import { TYPE } from '../../../theme'
+import { ButtonError } from 'components/Button'
+import { AutoColumn } from 'components/Column'
+import Modal from 'components/Modal'
+import QuestionHelper from 'components/QuestionHelper'
+import { RowBetween, RowFixed } from 'components/Row'
+import Toggle from 'components/Toggle'
+import TransactionSettings from 'components/TransactionSettings'
+import { StyledMenuButton, MenuFlyout, StyledMenu } from '../StyledMenu'
+
+const StyledMenuIconSliders = styled(Sliders)`
+  height: 20px;
+  width: 20px;
+  transform: rotate(-90deg);
+
+  > * {
+    stroke: ${({ theme }) => theme.text3};
+  }
+
+  :hover {
+    stroke: ${({ theme }) => theme.text1};
+  }
+`
+
+const StyledCloseIcon = styled(X)`
+  height: 20px;
+  width: 20px;
+  :hover {
+    cursor: pointer;
+  }
+
+  > * {
+    stroke: ${({ theme }) => theme.text1};
+  }
+`
+
+const EmojiWrapper = styled.div`
+  position: absolute;
+  bottom: -6px;
+  right: 0px;
+  font-size: 14px;
+`
+
+const Break = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: ${({ theme }) => theme.bg3};
+`
+
+const ModalContentWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 0;
+  background-color: ${({ theme }) => theme.bg2};
+  border-radius: 20px;
+`
+
+const ExtendedMenuFlyout = styled(MenuFlyout)`
+  min-width: 20.125rem;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    min-width: 18.125rem;
+  `};
+`
+
+export default function SettingsTab() {
+  const node = useRef<HTMLDivElement>(null)
+  const open = useModalOpen(ApplicationModal.SETTINGS)
+  const toggle = useToggleSettingsMenu()
+
+  const theme = useContext(ThemeContext)
+  const [userSlippageTolerance, setUserslippageTolerance] = useUserSlippageTolerance()
+
+  const [ttl, setTtl] = useUserTransactionTTL()
+
+  const [expertMode, toggleExpertMode] = useExpertModeManager()
+
+  const [singleHopOnly, setSingleHopOnly] = useUserSingleHopOnly()
+
+  // show confirmation view before turning on
+  const [showConfirmation, setShowConfirmation] = useState(false)
+
+  useOnClickOutside(node, open ? toggle : undefined)
+
+  return (
+    <StyledMenu ref={node}>
+      <Modal isOpen={showConfirmation} onDismiss={() => setShowConfirmation(false)} maxHeight={100}>
+        <ModalContentWrapper>
+          <AutoColumn gap="lg">
+            <RowBetween style={{ padding: '0 2rem' }}>
+              <div />
+              <Text fontWeight={500} fontSize={20}>
+                Are you sure?
+              </Text>
+              <StyledCloseIcon onClick={() => setShowConfirmation(false)} />
+            </RowBetween>
+            <Break />
+            <AutoColumn gap="lg" style={{ padding: '0 2rem' }}>
+              <Text fontWeight={500} fontSize={20}>
+                Expert mode turns off the confirm transaction prompt and allows high slippage trades that often result
+                in bad rates and lost funds.
+              </Text>
+              <Text fontWeight={600} fontSize={20}>
+                ONLY USE THIS MODE IF YOU KNOW WHAT YOU ARE DOING.
+              </Text>
+              <ButtonError
+                error={true}
+                padding={'12px'}
+                onClick={() => {
+                  if (window.prompt(`Please type the word "confirm" to enable expert mode.`) === 'confirm') {
+                    toggleExpertMode()
+                    setShowConfirmation(false)
+                  }
+                }}
+              >
+                <Text fontSize={20} fontWeight={500} id="confirm-expert-mode">
+                  Turn On Expert Mode
+                </Text>
+              </ButtonError>
+            </AutoColumn>
+          </AutoColumn>
+        </ModalContentWrapper>
+      </Modal>
+      <StyledMenuButton onClick={toggle} id="open-settings-dialog-button">
+        <StyledMenuIconSliders />
+        {expertMode ? (
+          <EmojiWrapper>
+            <span role="img" aria-label="wizard-icon">
+              🧙
+            </span>
+          </EmojiWrapper>
+        ) : null}
+      </StyledMenuButton>
+      {open && (
+        <ExtendedMenuFlyout>
+          <AutoColumn gap="md" style={{ padding: '1rem' }}>
+            <Text fontWeight={600} fontSize={14}>
+              Transaction Settings
+            </Text>
+            <TransactionSettings
+              rawSlippage={userSlippageTolerance}
+              setRawSlippage={setUserslippageTolerance}
+              deadline={ttl}
+              setDeadline={setTtl}
+            />
+            <Text fontWeight={600} fontSize={14}>
+              Interface Settings
+            </Text>
+            <RowBetween>
+              <RowFixed>
+                <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
+                  Toggle Expert Mode
+                </TYPE.black>
+                <QuestionHelper text="Bypasses confirmation modals and allows high slippage trades. Use at your own risk." />
+              </RowFixed>
+              <Toggle
+                id="toggle-expert-mode-button"
+                isActive={expertMode}
+                toggle={
+                  expertMode
+                    ? () => {
+                        toggleExpertMode()
+                        setShowConfirmation(false)
+                      }
+                    : () => {
+                        toggle()
+                        setShowConfirmation(true)
+                      }
+                }
+              />
+            </RowBetween>
+            <RowBetween>
+              <RowFixed>
+                <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
+                  Disable Multihops
+                </TYPE.black>
+                <QuestionHelper text="Restricts swaps to direct pairs only." />
+              </RowFixed>
+              <Toggle
+                id="toggle-disable-multihop-button"
+                isActive={singleHopOnly}
+                toggle={() => (singleHopOnly ? setSingleHopOnly(false) : setSingleHopOnly(true))}
+              />
+            </RowBetween>
+          </AutoColumn>
+        </ExtendedMenuFlyout>
+      )}
+    </StyledMenu>
+  )
+}

--- a/src/prototype/components/StyledMenu/index.tsx
+++ b/src/prototype/components/StyledMenu/index.tsx
@@ -1,0 +1,65 @@
+import styled from 'styled-components'
+import { lighten } from 'polished'
+
+export const StyledMenuButton = styled.button`
+  position: relative;
+  width: 100%;
+  border: 2px solid transparent;
+  min-width: 36px;
+  height: 36px;
+  background-color: ${({ theme }) => theme.bg2};
+  padding: 0.15rem 0.5rem;
+  border-radius: ${({ theme }) => theme.borderRadius};
+
+  :hover,
+  :focus {
+    cursor: pointer;
+    outline: none;
+    background-color: ${({ theme }) => lighten(0.05, theme.bg1)};
+    border: 2px solid ${({ theme }) => theme.bg2};
+    > * {
+      stroke: ${({ theme }) => theme.text1};
+    }
+  }
+
+  svg {
+    margin-top: 2px;
+  }
+  > * {
+    stroke: ${({ theme }) => theme.text3};
+  }
+
+  // ${({ theme }) => theme.mediaWidth.upToMedium`
+  //   margin-left: 4px;
+  // `};
+`
+
+export const StyledMenu = styled.div`
+  margin-left: 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  text-align: left;
+
+  ${({ theme }) => theme.mediaWidth.upToExtra2Small`
+    margin-left: 0.2rem;
+  `};
+`
+
+export const MenuFlyout = styled.span`
+  min-width: 8.125rem;
+  background-color: ${({ theme }) => theme.bg3};
+  box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.01), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
+    0px 24px 32px rgba(0, 0, 0, 0.01);
+  border-radius: ${({ theme }) => theme.borderRadius};
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+  position: absolute;
+  top: 3rem;
+  right: 0rem;
+  z-index: 100;
+`

--- a/src/prototype/components/ToggleButton/index.tsx
+++ b/src/prototype/components/ToggleButton/index.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react'
+import styled from 'styled-components'
+import { lighten } from 'polished'
+
+const StyledToggleButton = styled.button<{ selected?: boolean }>`
+  align-items: center;
+  font-size: 16px;
+  font-weight: 600;
+  color: ${({ selected, theme }) => (selected ? theme.text1 : theme.text3)}
+  background-color: ${({ selected, theme }) => (selected ? theme.bg1 : theme.bg2)};
+  border-radius: 9px;
+  outline: none;
+  cursor: pointer;
+  user-select: none;
+  border: none;
+  padding: 8px 12px;
+
+  :focus,
+  :hover {
+    background-color: ${({ theme }) => lighten(0.05, theme.bg1)};
+  }
+`
+
+export interface ToggleButtonProps {
+  value: string
+  selected?: boolean
+}
+
+const ToggleButton: FC<ToggleButtonProps> = props => {
+  return <StyledToggleButton {...props} />
+}
+
+export default ToggleButton

--- a/src/prototype/components/ToggleButtonGroup/index.tsx
+++ b/src/prototype/components/ToggleButtonGroup/index.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from 'react'
+import styled from 'styled-components'
+import { ToggleButtonProps } from '../ToggleButton'
+
+const StyledToggleButtonGroup = styled.div`
+  background-color: ${({ theme }) => theme.bg2};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  padding: 2px;
+
+  > *:first-child {
+    margin-left: 0;
+  }
+
+  > * {
+    margin-left: 2px;
+  }
+`
+
+interface ToggleButtonGroupProps {
+  value: any
+  onChange: (event: React.MouseEvent<HTMLElement>, newType: any) => void
+  children?: React.ReactElement<ToggleButtonProps> | React.ReactElement<ToggleButtonProps>[]
+}
+
+const ToggleButtonGroup: FC<ToggleButtonGroupProps> = ({ value, onChange, children }) => {
+  const childrenWithProps = React.Children.map(children, child => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child, {
+        onClick: (e: React.MouseEvent<HTMLElement>) => onChange(e, child.props.value),
+        selected: value === child.props.value
+      })
+    }
+    return child
+  })
+
+  return <StyledToggleButtonGroup>{childrenWithProps}</StyledToggleButtonGroup>
+}
+
+export default ToggleButtonGroup

--- a/src/prototype/components/swap/SwapHeader.tsx
+++ b/src/prototype/components/swap/SwapHeader.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import styled from 'styled-components'
+import Settings from '../Settings'
+import { RowBetween, RowFixed } from 'components/Row'
+import RefreshButton from '../RefreshButton'
+import GasIconButton from '../GasIconButton'
+import SwapTypeToggle from './SwapTypeToggle'
+
+const StyledSwapHeader = styled.div`
+  padding: 1rem 1rem 0px 1rem;
+  margin-bottom: -4px;
+  width: 100%;
+  color: ${({ theme }) => theme.text2};
+`
+
+export default function SwapHeader() {
+  return (
+    <StyledSwapHeader>
+      <RowBetween>
+        <SwapTypeToggle />
+        <RowFixed>
+          <GasIconButton />
+          <RefreshButton />
+          <Settings />
+        </RowFixed>
+      </RowBetween>
+    </StyledSwapHeader>
+  )
+}

--- a/src/prototype/components/swap/SwapTypeToggle.tsx
+++ b/src/prototype/components/swap/SwapTypeToggle.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react'
+import ToggleButton from '../ToggleButton'
+import ToggleButtonGroup from '../ToggleButtonGroup'
+
+const SwapTypeToggle = () => {
+  const [type, setType] = useState<string | null>('swap')
+
+  const handleChange = (event: React.MouseEvent<HTMLElement>, newType: string | null) => {
+    setType(newType)
+  }
+
+  return (
+    <ToggleButtonGroup value={type} onChange={handleChange}>
+      <ToggleButton value="swap">Swap</ToggleButton>
+      <ToggleButton value="limit">Limit</ToggleButton>
+      <ToggleButton value="lp">LP</ToggleButton>
+    </ToggleButtonGroup>
+  )
+}
+
+export default SwapTypeToggle

--- a/src/prototype/components/swap/TradePrice.tsx
+++ b/src/prototype/components/swap/TradePrice.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Price } from '@sushiswap/sdk'
+import { useContext } from 'react'
+import { Repeat } from 'react-feather'
+import { Text } from 'rebass'
+import styled, { ThemeContext } from 'styled-components'
+import { useActiveWeb3React } from '../../../hooks'
+
+const RepeatIconWrapper = styled.span`
+  width: 20px;
+  height: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`
+
+interface TradePriceProps {
+  price?: Price
+  showInverted: boolean
+  setShowInverted: (showInverted: boolean) => void
+}
+
+export default function TradePrice({ price, showInverted, setShowInverted }: TradePriceProps) {
+  const { chainId } = useActiveWeb3React()
+  const theme = useContext(ThemeContext)
+
+  const formattedPrice = showInverted ? price?.toSignificant(6) : price?.invert()?.toSignificant(6)
+
+  const show = Boolean(price?.baseCurrency && price?.quoteCurrency)
+  const label = !showInverted ? (
+    <span>
+      <strong>{formattedPrice}</strong> {price?.quoteCurrency?.getSymbol(chainId)} = <strong>1</strong>{' '}
+      {price?.baseCurrency?.getSymbol(chainId)}
+    </span>
+  ) : (
+    <span>
+      <strong>{formattedPrice}</strong> {price?.baseCurrency?.getSymbol(chainId)} = <strong>1</strong>{' '}
+      {price?.quoteCurrency?.getSymbol(chainId)}
+    </span>
+  )
+
+  return (
+    <Text
+      fontWeight={500}
+      fontSize={13}
+      color={theme.text3}
+      style={{ justifyContent: 'center', alignItems: 'center', display: 'flex' }}
+    >
+      {show ? (
+        <>
+          {label ?? '-'}
+          <RepeatIconWrapper role="button" onClick={() => setShowInverted(!showInverted)}>
+            <Repeat size={14} />
+          </RepeatIconWrapper>
+        </>
+      ) : (
+        '-'
+      )}
+    </Text>
+  )
+}

--- a/src/prototype/components/swap/styleds.tsx
+++ b/src/prototype/components/swap/styleds.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+import styled from 'styled-components'
+
+export const Wrapper = styled.div`
+  position: relative;
+  padding: 12px;
+`

--- a/src/prototype/pages/Swap2/index.tsx
+++ b/src/prototype/pages/Swap2/index.tsx
@@ -1,0 +1,547 @@
+import { CurrencyAmount, JSBI, Token, Trade } from '@sushiswap/sdk'
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { ArrowDown } from 'react-feather'
+import ReactGA from 'react-ga'
+import { Text } from 'rebass'
+import { ThemeContext } from 'styled-components'
+import AddressInputPanel from 'components/AddressInputPanel'
+import { ButtonError, ButtonLight, ButtonPrimary, ButtonConfirmed } from '../../components/Button'
+import Card, { GreyCard } from 'components/Card'
+import Column, { AutoColumn } from 'components/Column'
+import ConfirmSwapModal from 'components/swap/ConfirmSwapModal'
+import CurrencyInputPanel from '../../components/CurrencyInputPanel'
+import { SwapPoolTabs } from 'components/NavigationTabs'
+import { AutoRow, RowBetween } from 'components/Row'
+import AdvancedSwapDetailsSection from 'components/swap/AdvancedSwapDetailsSection'
+import BetterTradeLink, { DefaultVersionLink } from 'components/swap/BetterTradeLink'
+import confirmPriceImpactWithoutFee from 'components/swap/confirmPriceImpactWithoutFee'
+import { ArrowWrapper, BottomGrouping, SwapCallbackError } from 'components/swap/styleds'
+import { Wrapper } from '../../components/swap/styleds'
+import TradePrice from '../../components/swap/TradePrice'
+import TokenWarningModal from 'components/TokenWarningModal'
+import ProgressSteps from 'components/ProgressSteps'
+import SwapHeader from '../../components/swap/SwapHeader'
+
+import { INITIAL_ALLOWED_SLIPPAGE } from '../../../constants'
+import { getTradeVersion } from '../../../data/V1'
+import { useActiveWeb3React } from '../../../hooks'
+import { useCurrency, useAllTokens } from '../../../hooks/Tokens'
+import { ApprovalState, useApproveCallbackFromTrade } from '../../../hooks/useApproveCallback'
+import useENSAddress from '../../../hooks/useENSAddress'
+import { useSwapCallback } from '../../../hooks/useSwapCallback'
+import useToggledVersion, { DEFAULT_VERSION, Version } from '../../../hooks/useToggledVersion'
+import useWrapCallback, { WrapType } from '../../../hooks/useWrapCallback'
+import { useToggleSettingsMenu, useWalletModalToggle } from '../../../state/application/hooks'
+import { Field } from '../../../state/swap/actions'
+import {
+  useDefaultsFromURLSearch,
+  useDerivedSwapInfo,
+  useSwapActionHandlers,
+  useSwapState
+} from '../../../state/swap/hooks'
+import { useExpertModeManager, useUserSlippageTolerance, useUserSingleHopOnly } from '../../../state/user/hooks'
+import { LinkStyledButton, TYPE } from '../../../theme'
+import { maxAmountSpend } from '../../../utils/maxAmountSpend'
+import { computeTradePriceBreakdown, warningSeverity } from '../../../utils/prices'
+import AppBody from '../../AppBody'
+import { ClickableText } from '../../../pages/Pool/styleds'
+import Loader from 'components/Loader'
+import { useIsTransactionUnsupported } from 'hooks/Trades'
+import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter'
+import { isTradeBetter } from 'utils/trades'
+import CurrencyInputPanelSwitch from '../../components/CurrencyInputPanelSwitch'
+import ThemeProvider from '../../theme'
+
+const Swap = () => {
+  const loadedUrlParams = useDefaultsFromURLSearch()
+
+  // token warning stuff
+  const [loadedInputCurrency, loadedOutputCurrency] = [
+    useCurrency(loadedUrlParams?.inputCurrencyId),
+    useCurrency(loadedUrlParams?.outputCurrencyId)
+  ]
+  const [dismissTokenWarning, setDismissTokenWarning] = useState<boolean>(false)
+  const urlLoadedTokens: Token[] = useMemo(
+    () => [loadedInputCurrency, loadedOutputCurrency]?.filter((c): c is Token => c instanceof Token) ?? [],
+    [loadedInputCurrency, loadedOutputCurrency]
+  )
+  const handleConfirmTokenWarning = useCallback(() => {
+    setDismissTokenWarning(true)
+  }, [])
+
+  // dismiss warning if all imported tokens are in active lists
+  const defaultTokens = useAllTokens()
+  const importTokensNotInDefault =
+    urlLoadedTokens &&
+    urlLoadedTokens.filter((token: Token) => {
+      return !Boolean(token.address in defaultTokens)
+    })
+
+  const { account, chainId } = useActiveWeb3React()
+  const theme = useContext(ThemeContext)
+
+  // toggle wallet when disconnected
+  const toggleWalletModal = useWalletModalToggle()
+
+  // for expert mode
+  const toggleSettings = useToggleSettingsMenu()
+  const [isExpertMode] = useExpertModeManager()
+
+  // get custom setting values for user
+  const [allowedSlippage] = useUserSlippageTolerance()
+
+  // swap state
+  const { independentField, typedValue, recipient } = useSwapState()
+  const {
+    v1Trade,
+    v2Trade,
+    currencyBalances,
+    parsedAmount,
+    currencies,
+    inputError: swapInputError
+  } = useDerivedSwapInfo()
+  const { wrapType, execute: onWrap, inputError: wrapInputError } = useWrapCallback(
+    currencies[Field.INPUT],
+    currencies[Field.OUTPUT],
+    typedValue
+  )
+  const showWrap: boolean = wrapType !== WrapType.NOT_APPLICABLE
+  const { address: recipientAddress } = useENSAddress(recipient)
+  const toggledVersion = useToggledVersion()
+  const tradesByVersion = {
+    [Version.v1]: v1Trade,
+    [Version.v2]: v2Trade
+  }
+  const trade = showWrap ? undefined : tradesByVersion[toggledVersion]
+  const defaultTrade = showWrap ? undefined : tradesByVersion[DEFAULT_VERSION]
+
+  const betterTradeLinkV2: Version | undefined =
+    toggledVersion === Version.v1 && isTradeBetter(v1Trade, v2Trade) ? Version.v2 : undefined
+
+  const parsedAmounts = showWrap
+    ? {
+        [Field.INPUT]: parsedAmount,
+        [Field.OUTPUT]: parsedAmount
+      }
+    : {
+        [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmount,
+        [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmount
+      }
+
+  const { onSwitchTokens, onCurrencySelection, onUserInput, onChangeRecipient } = useSwapActionHandlers()
+  const isValid = !swapInputError
+  const dependentField: Field = independentField === Field.INPUT ? Field.OUTPUT : Field.INPUT
+
+  const handleTypeInput = useCallback(
+    (value: string) => {
+      onUserInput(Field.INPUT, value)
+    },
+    [onUserInput]
+  )
+  const handleTypeOutput = useCallback(
+    (value: string) => {
+      onUserInput(Field.OUTPUT, value)
+    },
+    [onUserInput]
+  )
+
+  // modal and loading
+  const [{ showConfirm, tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{
+    showConfirm: boolean
+    tradeToConfirm: Trade | undefined
+    attemptingTxn: boolean
+    swapErrorMessage: string | undefined
+    txHash: string | undefined
+  }>({
+    showConfirm: false,
+    tradeToConfirm: undefined,
+    attemptingTxn: false,
+    swapErrorMessage: undefined,
+    txHash: undefined
+  })
+
+  const formattedAmounts = {
+    [independentField]: typedValue,
+    [dependentField]: showWrap
+      ? parsedAmounts[independentField]?.toExact() ?? ''
+      : parsedAmounts[dependentField]?.toSignificant(6) ?? ''
+  }
+
+  const route = trade?.route
+  const userHasSpecifiedInputOutput = Boolean(
+    currencies[Field.INPUT] && currencies[Field.OUTPUT] && parsedAmounts[independentField]?.greaterThan(JSBI.BigInt(0))
+  )
+  const noRoute = !route
+
+  // check whether the user has approved the router on the input token
+  const [approval, approveCallback] = useApproveCallbackFromTrade(trade, allowedSlippage)
+
+  // check if user has gone through approval process, used to show two step buttons, reset on token change
+  const [approvalSubmitted, setApprovalSubmitted] = useState<boolean>(false)
+
+  // mark when a user has submitted an approval, reset onTokenSelection for input field
+  useEffect(() => {
+    if (approval === ApprovalState.PENDING) {
+      setApprovalSubmitted(true)
+    }
+  }, [approval, approvalSubmitted])
+
+  const maxAmountInput: CurrencyAmount | undefined = maxAmountSpend(currencyBalances[Field.INPUT])
+  const atMaxAmountInput = Boolean(maxAmountInput && parsedAmounts[Field.INPUT]?.equalTo(maxAmountInput))
+
+  // the callback to execute the swap
+  const { callback: swapCallback, error: swapCallbackError } = useSwapCallback(trade, allowedSlippage, recipient)
+
+  const { priceImpactWithoutFee } = computeTradePriceBreakdown(trade)
+
+  const [singleHopOnly] = useUserSingleHopOnly()
+
+  const handleSwap = useCallback(() => {
+    if (priceImpactWithoutFee && !confirmPriceImpactWithoutFee(priceImpactWithoutFee)) {
+      return
+    }
+    if (!swapCallback) {
+      return
+    }
+    setSwapState({ attemptingTxn: true, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: undefined })
+    swapCallback()
+      .then(hash => {
+        setSwapState({ attemptingTxn: false, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: hash })
+
+        ReactGA.event({
+          category: 'Swap',
+          action:
+            recipient === null
+              ? 'Swap w/o Send'
+              : (recipientAddress ?? recipient) === account
+              ? 'Swap w/o Send + recipient'
+              : 'Swap w/ Send',
+          label: [
+            trade?.inputAmount?.currency?.symbol,
+            trade?.outputAmount?.currency?.symbol,
+            getTradeVersion(trade)
+          ].join('/')
+        })
+
+        ReactGA.event({
+          category: 'Routing',
+          action: singleHopOnly ? 'Swap with multihop disabled' : 'Swap with multihop enabled'
+        })
+      })
+      .catch(error => {
+        setSwapState({
+          attemptingTxn: false,
+          tradeToConfirm,
+          showConfirm,
+          swapErrorMessage: error.message,
+          txHash: undefined
+        })
+      })
+  }, [
+    priceImpactWithoutFee,
+    swapCallback,
+    tradeToConfirm,
+    showConfirm,
+    recipient,
+    recipientAddress,
+    account,
+    trade,
+    singleHopOnly
+  ])
+
+  // errors
+  const [showInverted, setShowInverted] = useState<boolean>(false)
+
+  // warnings on slippage
+  const priceImpactSeverity = warningSeverity(priceImpactWithoutFee)
+
+  // show approve flow when: no error on inputs, not approved or pending, or approved in current session
+  // never show if price impact is above threshold in non expert mode
+  const showApproveFlow =
+    !swapInputError &&
+    (approval === ApprovalState.NOT_APPROVED ||
+      approval === ApprovalState.PENDING ||
+      (approvalSubmitted && approval === ApprovalState.APPROVED)) &&
+    !(priceImpactSeverity > 3 && !isExpertMode)
+
+  const handleConfirmDismiss = useCallback(() => {
+    setSwapState({ showConfirm: false, tradeToConfirm, attemptingTxn, swapErrorMessage, txHash })
+    // if there was a tx hash, we want to clear the input
+    if (txHash) {
+      onUserInput(Field.INPUT, '')
+    }
+  }, [attemptingTxn, onUserInput, swapErrorMessage, tradeToConfirm, txHash])
+
+  const handleAcceptChanges = useCallback(() => {
+    setSwapState({ tradeToConfirm: trade, swapErrorMessage, txHash, attemptingTxn, showConfirm })
+  }, [attemptingTxn, showConfirm, swapErrorMessage, trade, txHash])
+
+  const handleInputSelect = useCallback(
+    inputCurrency => {
+      setApprovalSubmitted(false) // reset 2 step UI for approvals
+      onCurrencySelection(Field.INPUT, inputCurrency)
+    },
+    [onCurrencySelection]
+  )
+
+  const handleMaxInput = useCallback(() => {
+    maxAmountInput && onUserInput(Field.INPUT, maxAmountInput.toExact())
+  }, [maxAmountInput, onUserInput])
+
+  const handleOutputSelect = useCallback(outputCurrency => onCurrencySelection(Field.OUTPUT, outputCurrency), [
+    onCurrencySelection
+  ])
+
+  const swapIsUnsupported = useIsTransactionUnsupported(currencies?.INPUT, currencies?.OUTPUT)
+
+  return (
+    <>
+      <TokenWarningModal
+        isOpen={importTokensNotInDefault.length > 0 && !dismissTokenWarning}
+        tokens={importTokensNotInDefault}
+        onConfirm={handleConfirmTokenWarning}
+      />
+      <SwapPoolTabs active={'swap'} />
+      <AppBody>
+        <SwapHeader />
+        <Wrapper id="swap-page">
+          <ConfirmSwapModal
+            isOpen={showConfirm}
+            trade={trade}
+            originalTrade={tradeToConfirm}
+            onAcceptChanges={handleAcceptChanges}
+            attemptingTxn={attemptingTxn}
+            txHash={txHash}
+            recipient={recipient}
+            allowedSlippage={allowedSlippage}
+            onConfirm={handleSwap}
+            swapErrorMessage={swapErrorMessage}
+            onDismiss={handleConfirmDismiss}
+          />
+          {/* <AutoColumn gap={isExpertMode ? 'md' : 'none'} style={{ paddingBottom: '1rem' }}> */}
+          <AutoColumn gap={isExpertMode ? 'md' : ''}>
+            <CurrencyInputPanel
+              label={independentField === Field.OUTPUT && !showWrap && trade ? 'From (estimated)' : 'From'}
+              value={formattedAmounts[Field.INPUT]}
+              showMaxButton={!atMaxAmountInput}
+              currency={currencies[Field.INPUT]}
+              onUserInput={handleTypeInput}
+              onMax={handleMaxInput}
+              onCurrencySelect={handleInputSelect}
+              otherCurrency={currencies[Field.OUTPUT]}
+              id="swap-currency-input"
+              cornerRadiusBottomNone={false}
+              isInputPanel={true}
+              //containerBackground={'#101b31'}
+            />
+            {isExpertMode && !showWrap && (
+              <AutoColumn justify="space-between">
+                <AutoRow justify={isExpertMode ? 'space-between' : 'center'} style={{ padding: '0 1rem' }}>
+                  <ArrowWrapper clickable>
+                    <ArrowDown
+                      size="16"
+                      onClick={() => {
+                        setApprovalSubmitted(false) // reset 2 step UI for approvals
+                        onSwitchTokens()
+                      }}
+                      color={currencies[Field.INPUT] && currencies[Field.OUTPUT] ? theme.primary1 : theme.text2}
+                    />
+                  </ArrowWrapper>
+                  {recipient === null && !showWrap && isExpertMode ? (
+                    <LinkStyledButton id="add-recipient-button" onClick={() => onChangeRecipient('')}>
+                      + Add a send (optional)
+                    </LinkStyledButton>
+                  ) : null}
+                </AutoRow>
+              </AutoColumn>
+            )}
+            {!isExpertMode && (
+              <CurrencyInputPanelSwitch onSwitchTokens={onSwitchTokens} setApprovalSubmitted={setApprovalSubmitted} />
+            )}
+            <CurrencyInputPanel
+              value={formattedAmounts[Field.OUTPUT]}
+              onUserInput={handleTypeOutput}
+              label={independentField === Field.INPUT && !showWrap && trade ? 'To (estimated)' : 'To'}
+              showMaxButton={false}
+              currency={currencies[Field.OUTPUT]}
+              onCurrencySelect={handleOutputSelect}
+              otherCurrency={currencies[Field.INPUT]}
+              id="swap-currency-output"
+              cornerRadiusBottomNone={Boolean(trade)}
+              //containerBackground={'#16182b'}
+            >
+              {Boolean(trade) && (
+                <RowBetween
+                  align="center"
+                  style={{
+                    border: `2px solid ${theme.bg2}`,
+                    backgroundColor: theme.bg1,
+                    padding: '0 12px',
+                    borderRadius: '0 0 12px 12px'
+                  }}
+                >
+                  <Text fontWeight={600} fontSize={13} color={theme.text3}>
+                    Current rate
+                  </Text>
+                  <TradePrice
+                    price={trade?.executionPrice}
+                    showInverted={showInverted}
+                    setShowInverted={setShowInverted}
+                  />
+                </RowBetween>
+              )}
+            </CurrencyInputPanel>
+
+            {recipient !== null && !showWrap ? (
+              <>
+                <AutoRow justify="space-between" style={{ padding: '0 1rem' }}>
+                  <ArrowWrapper clickable={false}>
+                    <ArrowDown size="16" color={theme.text2} />
+                  </ArrowWrapper>
+                  <LinkStyledButton id="remove-recipient-button" onClick={() => onChangeRecipient(null)}>
+                    - Remove send
+                  </LinkStyledButton>
+                </AutoRow>
+                <AddressInputPanel id="recipient" value={recipient} onChange={onChangeRecipient} />
+              </>
+            ) : null}
+          </AutoColumn>
+          <BottomGrouping style={{ paddingBottom: '1rem' }}>
+            {swapIsUnsupported ? (
+              <ButtonPrimary disabled={true}>
+                <TYPE.main mb="4px">Unsupported Asset</TYPE.main>
+              </ButtonPrimary>
+            ) : !account ? (
+              <ButtonLight onClick={toggleWalletModal}>Connect Wallet</ButtonLight>
+            ) : showWrap ? (
+              <ButtonPrimary disabled={Boolean(wrapInputError)} onClick={onWrap}>
+                {wrapInputError ??
+                  (wrapType === WrapType.WRAP ? 'Wrap' : wrapType === WrapType.UNWRAP ? 'Unwrap' : null)}
+              </ButtonPrimary>
+            ) : noRoute && userHasSpecifiedInputOutput ? (
+              <GreyCard style={{ textAlign: 'center' }}>
+                <TYPE.main mb="4px">Insufficient liquidity for this trade.</TYPE.main>
+                {singleHopOnly && <TYPE.main mb="4px">Try enabling multi-hop trades.</TYPE.main>}
+              </GreyCard>
+            ) : showApproveFlow ? (
+              <RowBetween>
+                <ButtonConfirmed
+                  onClick={approveCallback}
+                  disabled={approval !== ApprovalState.NOT_APPROVED || approvalSubmitted}
+                  width="48%"
+                  altDisabledStyle={approval === ApprovalState.PENDING} // show solid button while waiting
+                  confirmed={approval === ApprovalState.APPROVED}
+                >
+                  {approval === ApprovalState.PENDING ? (
+                    <AutoRow gap="6px" justify="center">
+                      Approving <Loader stroke="white" />
+                    </AutoRow>
+                  ) : approvalSubmitted && approval === ApprovalState.APPROVED ? (
+                    'Approved'
+                  ) : (
+                    'Approve ' + currencies[Field.INPUT]?.getSymbol(chainId)
+                  )}
+                </ButtonConfirmed>
+                <ButtonError
+                  onClick={() => {
+                    if (isExpertMode) {
+                      handleSwap()
+                    } else {
+                      setSwapState({
+                        tradeToConfirm: trade,
+                        attemptingTxn: false,
+                        swapErrorMessage: undefined,
+                        showConfirm: true,
+                        txHash: undefined
+                      })
+                    }
+                  }}
+                  width="48%"
+                  id="swap-button"
+                  disabled={
+                    !isValid || approval !== ApprovalState.APPROVED || (priceImpactSeverity > 3 && !isExpertMode)
+                  }
+                  error={isValid && priceImpactSeverity > 2}
+                >
+                  <Text fontSize={16} fontWeight={500}>
+                    {priceImpactSeverity > 3 && !isExpertMode
+                      ? `Price Impact High`
+                      : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`}
+                  </Text>
+                </ButtonError>
+              </RowBetween>
+            ) : (
+              <ButtonError
+                onClick={() => {
+                  if (isExpertMode) {
+                    handleSwap()
+                  } else {
+                    setSwapState({
+                      tradeToConfirm: trade,
+                      attemptingTxn: false,
+                      swapErrorMessage: undefined,
+                      showConfirm: true,
+                      txHash: undefined
+                    })
+                  }
+                }}
+                id="swap-button"
+                disabled={!isValid || (priceImpactSeverity > 3 && !isExpertMode) || !!swapCallbackError}
+                error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
+              >
+                <Text fontSize={20} fontWeight={500}>
+                  {swapInputError
+                    ? swapInputError
+                    : priceImpactSeverity > 3 && !isExpertMode
+                    ? `Price Impact Too High`
+                    : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`}
+                </Text>
+              </ButtonError>
+            )}
+            {showApproveFlow && (
+              <Column style={{ marginTop: '1rem' }}>
+                <ProgressSteps steps={[approval === ApprovalState.APPROVED]} />
+              </Column>
+            )}
+            {isExpertMode && swapErrorMessage ? <SwapCallbackError error={swapErrorMessage} /> : null}
+            {betterTradeLinkV2 && !swapIsUnsupported && toggledVersion === Version.v1 ? (
+              <BetterTradeLink version={betterTradeLinkV2} />
+            ) : toggledVersion !== DEFAULT_VERSION && defaultTrade ? (
+              <DefaultVersionLink />
+            ) : null}
+          </BottomGrouping>
+          <AutoColumn>
+            {showWrap ? null : (
+              <Card padding={showWrap ? '.25rem 1rem 0 1rem' : '0px'} borderRadius={'20px'}>
+                <AutoColumn gap="8px" style={{ padding: '0 16px' }}>
+                  {allowedSlippage !== INITIAL_ALLOWED_SLIPPAGE && (
+                    <RowBetween align="center">
+                      <ClickableText fontWeight={500} fontSize={14} color={theme.text2} onClick={toggleSettings}>
+                        Slippage Tolerance
+                      </ClickableText>
+                      <ClickableText fontWeight={500} fontSize={14} color={theme.text2} onClick={toggleSettings}>
+                        {allowedSlippage / 100}%
+                      </ClickableText>
+                    </RowBetween>
+                  )}
+                </AutoColumn>
+              </Card>
+            )}
+            <AdvancedSwapDetailsSection trade={trade} />
+          </AutoColumn>
+        </Wrapper>
+      </AppBody>
+      {!swapIsUnsupported ? null : (
+        <UnsupportedCurrencyFooter show={swapIsUnsupported} currencies={[currencies.INPUT, currencies.OUTPUT]} />
+      )}
+    </>
+  )
+}
+
+const SwapWithChildThemeOverride = () => (
+  <ThemeProvider>
+    <Swap />
+  </ThemeProvider>
+)
+
+export default SwapWithChildThemeOverride

--- a/src/prototype/theme/DarkModeQueryParamReader.tsx
+++ b/src/prototype/theme/DarkModeQueryParamReader.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { RouteComponentProps } from 'react-router-dom'
+import { parse } from 'qs'
+import { AppDispatch } from '../../state'
+import { updateUserDarkMode } from '../../state/user/actions'
+
+export default function DarkModeQueryParamReader({ location: { search } }: RouteComponentProps): null {
+  const dispatch = useDispatch<AppDispatch>()
+
+  useEffect(() => {
+    if (!search) return
+    if (search.length < 2) return
+
+    const parsed = parse(search, {
+      parseArrays: false,
+      ignoreQueryPrefix: true
+    })
+
+    const theme = parsed.theme
+
+    if (typeof theme !== 'string') return
+
+    if (theme.toLowerCase() === 'light') {
+      dispatch(updateUserDarkMode({ userDarkMode: false }))
+    } else if (theme.toLowerCase() === 'dark') {
+      dispatch(updateUserDarkMode({ userDarkMode: true }))
+    }
+  }, [dispatch, search])
+
+  return null
+}

--- a/src/prototype/theme/components.tsx
+++ b/src/prototype/theme/components.tsx
@@ -1,0 +1,307 @@
+import React, { HTMLProps, useCallback } from 'react'
+import ReactGA from 'react-ga'
+import { Link } from 'react-router-dom'
+import styled, { keyframes } from 'styled-components'
+import { darken } from 'polished'
+import { ArrowLeft, X, ExternalLink as LinkIconFeather, Trash } from 'react-feather'
+
+export const ButtonText = styled.button`
+  outline: none;
+  border: none;
+  font-size: inherit;
+  padding: 0;
+  margin: 0;
+  background: none;
+  cursor: pointer;
+
+  :hover {
+    opacity: 0.7;
+  }
+
+  :focus {
+    text-decoration: underline;
+  }
+`
+
+export const Button = styled.button.attrs<{ warning: boolean }, { backgroundColor: string }>(({ warning, theme }) => ({
+  backgroundColor: warning ? theme.red1 : theme.primary1
+}))`
+  padding: 1rem 2rem 1rem 2rem;
+  border-radius: 3rem;
+  cursor: pointer;
+  user-select: none;
+  font-size: 1rem;
+  border: none;
+  outline: none;
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  color: ${({ theme }) => theme.white};
+  width: 100%;
+
+  :hover,
+  :focus {
+    background-color: ${({ backgroundColor }) => darken(0.05, backgroundColor)};
+  }
+
+  :active {
+    background-color: ${({ backgroundColor }) => darken(0.1, backgroundColor)};
+  }
+
+  :disabled {
+    background-color: ${({ theme }) => theme.bg1};
+    color: ${({ theme }) => theme.text4};
+    cursor: auto;
+  }
+`
+
+export const CloseIcon = styled(X)<{ onClick: () => void }>`
+  cursor: pointer;
+`
+
+// for wrapper react feather icons
+export const IconWrapper = styled.div<{ stroke?: string; size?: string; marginRight?: string; marginLeft?: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${({ size }) => size ?? '20px'};
+  height: ${({ size }) => size ?? '20px'};
+  margin-right: ${({ marginRight }) => marginRight ?? 0};
+  margin-left: ${({ marginLeft }) => marginLeft ?? 0};
+  & > * {
+    stroke: ${({ theme, stroke }) => stroke ?? theme.blue1};
+  }
+`
+
+// A button that triggers some onClick result, but looks like a link.
+export const LinkStyledButton = styled.button<{ disabled?: boolean }>`
+  border: none;
+  text-decoration: none;
+  background: none;
+
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+  color: ${({ theme, disabled }) => (disabled ? theme.text2 : theme.primary1)};
+  font-weight: 500;
+
+  :hover {
+    text-decoration: ${({ disabled }) => (disabled ? null : 'underline')};
+  }
+
+  :focus {
+    outline: none;
+    text-decoration: ${({ disabled }) => (disabled ? null : 'underline')};
+  }
+
+  :active {
+    text-decoration: none;
+  }
+`
+
+// An internal link from the react-router-dom library that is correctly styled
+export const StyledInternalLink = styled(Link)`
+  text-decoration: none;
+  cursor: pointer;
+  color: ${({ theme }) => theme.primary1};
+  font-weight: 500;
+
+  :hover {
+    text-decoration: underline;
+  }
+
+  :focus {
+    outline: none;
+    text-decoration: underline;
+  }
+
+  :active {
+    text-decoration: none;
+  }
+`
+
+const StyledLink = styled.a`
+  text-decoration: none;
+  cursor: pointer;
+  color: #0094ec;
+  font-weight: 500;
+
+  :hover {
+    text-decoration: underline;
+  }
+
+  :focus {
+    outline: none;
+    text-decoration: underline;
+  }
+
+  :active {
+    text-decoration: none;
+  }
+`
+
+const LinkIconWrapper = styled.a`
+  text-decoration: none;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+
+  :hover {
+    text-decoration: none;
+    opacity: 0.7;
+  }
+
+  :focus {
+    outline: none;
+    text-decoration: none;
+  }
+
+  :active {
+    text-decoration: none;
+  }
+`
+
+export const LinkIcon = styled(LinkIconFeather)`
+  height: 16px;
+  width: 18px;
+  margin-left: 10px;
+  stroke: ${({ theme }) => theme.blue1};
+`
+
+export const TrashIcon = styled(Trash)`
+  height: 16px;
+  width: 18px;
+  margin-left: 10px;
+  stroke: ${({ theme }) => theme.text3};
+
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+
+  :hover {
+    opacity: 0.7;
+  }
+`
+
+const rotateImg = keyframes`
+  0% {
+    transform: perspective(1000px) rotateY(0deg);
+  }
+
+  100% {
+    transform: perspective(1000px) rotateY(360deg);
+  }
+`
+
+export const UniTokenAnimated = styled.img`
+  animation: ${rotateImg} 5s cubic-bezier(0.83, 0, 0.17, 1) infinite;
+  padding: 2rem 0 0 0;
+  filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.15));
+`
+
+/**
+ * Outbound link that handles firing google analytics events
+ */
+export function ExternalLink({
+  target = '_blank',
+  href,
+  rel = 'noopener noreferrer',
+  ...rest
+}: Omit<HTMLProps<HTMLAnchorElement>, 'as' | 'ref' | 'onClick'> & { href: string }) {
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      // don't prevent default, don't redirect if it's a new tab
+      if (target === '_blank' || event.ctrlKey || event.metaKey) {
+        ReactGA.outboundLink({ label: href }, () => {
+          console.debug('Fired outbound link event', href)
+        })
+      } else {
+        event.preventDefault()
+        // send a ReactGA event and then trigger a location change
+        ReactGA.outboundLink({ label: href }, () => {
+          window.location.href = href
+        })
+      }
+    },
+    [href, target]
+  )
+  return <StyledLink target={target} rel={rel} href={href} onClick={handleClick} {...rest} />
+}
+
+export function ExternalLinkIcon({
+  target = '_blank',
+  href,
+  rel = 'noopener noreferrer',
+  ...rest
+}: Omit<HTMLProps<HTMLAnchorElement>, 'as' | 'ref' | 'onClick'> & { href: string }) {
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      // don't prevent default, don't redirect if it's a new tab
+      if (target === '_blank' || event.ctrlKey || event.metaKey) {
+        ReactGA.outboundLink({ label: href }, () => {
+          console.debug('Fired outbound link event', href)
+        })
+      } else {
+        event.preventDefault()
+        // send a ReactGA event and then trigger a location change
+        ReactGA.outboundLink({ label: href }, () => {
+          window.location.href = href
+        })
+      }
+    },
+    [href, target]
+  )
+  return (
+    <LinkIconWrapper target={target} rel={rel} href={href} onClick={handleClick} {...rest}>
+      <LinkIcon />
+    </LinkIconWrapper>
+  )
+}
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+export const Spinner = styled.img`
+  animation: 2s ${rotate} linear infinite;
+  width: 16px;
+  height: 16px;
+`
+
+const BackArrowLink = styled(StyledInternalLink)`
+  color: ${({ theme }) => theme.text1};
+`
+export function BackArrow({ to }: { to: string }) {
+  return (
+    <BackArrowLink to={to}>
+      <ArrowLeft />
+    </BackArrowLink>
+  )
+}
+
+export const CustomLightSpinner = styled(Spinner)<{ size: string }>`
+  height: ${({ size }) => size};
+  width: ${({ size }) => size};
+`
+
+export const HideSmall = styled.span`
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    display: none;
+  `};
+`
+
+export const HideExtraSmall = styled.span`
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    display: none;
+  `};
+`
+
+export const ExtraSmallOnly = styled.span`
+  display: none;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    display: block;
+  `};
+`

--- a/src/prototype/theme/index.tsx
+++ b/src/prototype/theme/index.tsx
@@ -1,0 +1,240 @@
+import { transparentize } from 'polished'
+import React, { useMemo } from 'react'
+import styled, {
+  ThemeProvider as StyledComponentsThemeProvider,
+  createGlobalStyle,
+  css,
+  DefaultTheme
+} from 'styled-components'
+import { useIsDarkMode } from '../../state/user/hooks'
+import { Text, TextProps } from 'rebass'
+import { Colors } from '../../theme/styled'
+
+export * from './components'
+
+export enum ThemeName {
+  uni = 'uni',
+  sushi = 'sushi'
+}
+
+const MEDIA_WIDTHS = {
+  upToExtra2Small: 320,
+  upToExtraSmall: 500,
+  upToSmall: 720,
+  upToMedium: 960,
+  upToLarge: 1280
+}
+
+const mediaWidthTemplates: { [width in keyof typeof MEDIA_WIDTHS]: typeof css } = Object.keys(MEDIA_WIDTHS).reduce(
+  (accumulator, size) => {
+    ;(accumulator as any)[size] = (a: any, b: any, c: any) => css`
+      @media (max-width: ${(MEDIA_WIDTHS as any)[size]}px) {
+        ${css(a, b, c)}
+      }
+    `
+    return accumulator
+  },
+  {}
+) as any
+
+const white = '#FFFFFF'
+const black = '#000000'
+
+export function colors(darkMode: boolean): Colors {
+  return {
+    // base
+    white,
+    black,
+
+    // text
+    text1: darkMode ? '#FFFFFF' : '#000000',
+    text2: darkMode ? '#C3C5CB' : '#565A69',
+    text3: darkMode ? '#5C5378' : '#888D9B',
+    text4: darkMode ? '#565A69' : '#C3C5CB',
+    text5: darkMode ? '#2C2F36' : '#EDEEF2',
+
+    // backgrounds / greys
+    bg1: darkMode ? '#161320' : '#FFFFFF',
+    bg2: darkMode ? '#06020D' : '#F7F8FA',
+    bg3: darkMode ? '#2a3a50' : '#EDEEF2',
+    bg4: darkMode ? '#3a506f' : '#CED0D9',
+    bg5: darkMode ? '#6C7284' : '#888D9B',
+
+    //specialty colors
+    modalBG: darkMode ? 'rgba(0,0,0,.425)' : 'rgba(0,0,0,0.3)',
+    advancedBG: darkMode ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.6)',
+
+    //primary colors
+    primary1: darkMode ? '#0094ec' : '#0e0e23',
+    primary2: darkMode ? '#0097fb' : '#FF8CC3',
+    primary3: darkMode ? '#00aff5' : '#FF99C9',
+    primary4: darkMode ? '#376bad70' : '#F6DDE8',
+    primary5: darkMode ? '#153d6f70' : '#ebebeb',
+
+    // color text
+    primaryText1: darkMode ? '#6da8ff' : '#0e0e23',
+
+    // secondary colors
+    secondary1: darkMode ? '#58B5F6' : '#ff007a',
+    secondary2: darkMode ? '#C64A92' : '#F6DDE8',
+    secondary3: darkMode ? '#17000b26' : '#ebebeb',
+
+    // other
+    red1: '#FD4040',
+    red2: '#F82D3A',
+    red3: '#D60000',
+    green1: '#27AE60',
+    yellow1: '#FFE270',
+    yellow2: '#F3841E',
+    blue1: '#0094ec',
+
+    borderRadius: '12px'
+
+    // dont wanna forget these blue yet
+    // blue4: darkMode ? '#153d6f70' : '#C4D9F8',
+    // blue5: darkMode ? '#153d6f70' : '#EBF4FF',
+  }
+}
+
+export function theme(darkMode: boolean): DefaultTheme {
+  return {
+    ...colors(darkMode),
+
+    grids: {
+      sm: 8,
+      md: 12,
+      lg: 24
+    },
+
+    //shadows
+    shadow1: darkMode ? '#000' : '#2F80ED',
+
+    // media queries
+    mediaWidth: mediaWidthTemplates,
+
+    // css snippets
+    flexColumnNoWrap: css`
+      display: flex;
+      flex-flow: column nowrap;
+    `,
+    flexRowNoWrap: css`
+      display: flex;
+      flex-flow: row nowrap;
+    `
+  }
+}
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const darkMode = useIsDarkMode()
+
+  const themeObject = useMemo(() => theme(darkMode), [darkMode])
+
+  return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
+}
+
+const TextWrapper = styled(Text)<{ color: keyof Colors }>`
+  color: ${({ color, theme }) => (theme as any)[color]};
+`
+
+export const TYPE = {
+  main(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'text2'} {...props} />
+  },
+  link(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'primary1'} {...props} />
+  },
+  black(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'text1'} {...props} />
+  },
+  white(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'white'} {...props} />
+  },
+  body(props: TextProps) {
+    return <TextWrapper fontWeight={400} fontSize={16} color={'text1'} {...props} />
+  },
+  largeHeader(props: TextProps) {
+    return <TextWrapper fontWeight={600} fontSize={24} {...props} />
+  },
+  mediumHeader(props: TextProps) {
+    return <TextWrapper fontWeight={500} fontSize={20} {...props} />
+  },
+  subHeader(props: TextProps) {
+    return <TextWrapper fontWeight={400} fontSize={14} {...props} />
+  },
+  small(props: TextProps) {
+    return <TextWrapper fontWeight={500} fontSize={11} {...props} />
+  },
+  blue(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'blue1'} {...props} />
+  },
+  yellow(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'yellow1'} {...props} />
+  },
+  darkGray(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'text3'} {...props} />
+  },
+  gray(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'bg3'} {...props} />
+  },
+  italic(props: TextProps) {
+    return <TextWrapper fontWeight={500} fontSize={12} fontStyle={'italic'} color={'text2'} {...props} />
+  },
+  error({ error, ...props }: { error: boolean } & TextProps) {
+    return <TextWrapper fontWeight={500} color={error ? 'red1' : 'text2'} {...props} />
+  }
+}
+
+export const FixedGlobalStyle = createGlobalStyle`
+html, input, textarea, button {
+  font-family: 'Inter', sans-serif;
+  font-display: fallback;
+}
+@supports (font-variation-settings: normal) {
+  html, input, textarea, button {
+    font-family: 'Inter var', sans-serif;
+  }
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  color: ${colors(false).blue1};
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button {
+  user-select: none;
+}
+
+html {
+  font-size: 16px;
+  font-variant: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  font-feature-settings: 'ss01' on, 'ss02' on, 'cv01' on, 'cv03' on;
+  
+}
+`
+
+export const ThemedGlobalStyle = createGlobalStyle`
+html {
+  color: ${({ theme }) => theme.text1};
+  background-color: ${({ theme }) => theme.bg2};
+}
+
+body {
+  min-height: 100vh;
+  background-position: 0 -30vh;
+  background-repeat: no-repeat;
+  background-image: ${({ theme }) =>
+    `radial-gradient(50% 50% at 50% 50%, ${transparentize(0.8, '#db4690')} 0%, ${transparentize(1, '#db4690')} 100%)`};
+}
+`


### PR DESCRIPTION
Implements alternative swap styling according to the following image:

![](https://user-images.githubusercontent.com/70670294/111680335-1f2ee580-87f0-11eb-8450-a813f584be51.png)

Implemented:
- Create new page called `page2` that uses a child `ThemeProvider` which overrides the default theme
- Prototype folder structure (copy existing code), existing code is untouched

Not implemented:
- Toggle in header is not functional, does not switch the swap interface
- Gas color and price are not functional
- Refresh icon is not functional
- Lock icon is not functional
- In expert mode, fields were not adjusted to new styling
- USD pricing
- The mockup uses a different font than the current font used

I deliberately left out the additional functionality described in this task: https://github.com/sushiswap/sushiswap-interface/issues/36