### PR TITLE
Fix for page styling issue on mobile

### DIFF
--- a/src/pages/SushiBar/index.tsx
+++ b/src/pages/SushiBar/index.tsx
@@ -26,7 +26,7 @@ export default function XSushi() {
             <Helmet>
                 <title>xSUSHI | Sushi</title>
             </Helmet>
-            <div className="flex flex-col w-full">
+            <div className="flex flex-col w-full min-h-fitContent">
                 <div className="flex mb-6 justify-center">
                     <InfoCard />
                     <div className="hidden md:flex justify-center align-center w-72 ml-6">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -206,7 +206,8 @@ module.exports = {
                 }
             },
             minHeight: {
-                cardContent: '230px'
+                cardContent: '230px',
+                fitContent: 'fit-content'
             }
         }
     },


### PR DESCRIPTION
This PR solved the issue for #113 

It was a height issue only appearing on certain Iphones. The main element didn't calculate the height based on the child elements, making it compress the content. Adding `min-height: fit-content` to the main element seems to solve it.

Issue can be reproduced on: https://app.sushi.com/sushibar on Iphone 12 Safari.