### PR TITLE
Fix typo: "avaialble" -> "available"

### DIFF
--- a/src/language/locales/de/catalog.json
+++ b/src/language/locales/de/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "Nach",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "Expertenmodus umschalten",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/en/catalog.json
+++ b/src/language/locales/en/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.",
   "To": "To",
   "To (estimated)": "To (estimated)",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.",
   "Toggle Expert Mode": "Toggle Expert Mode",
   "Token": "Token",
   "Tokens": "Tokens",

--- a/src/language/locales/es-AR/catalog.json
+++ b/src/language/locales/es-AR/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "A",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/es/catalog.json
+++ b/src/language/locales/es/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "A",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "Alternar modo experto",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/fr/catalog.json
+++ b/src/language/locales/fr/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "À",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "Activer le mode expert",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/he/catalog.json
+++ b/src/language/locales/he/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "ל",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "החלף מצב מומחה",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/it/catalog.json
+++ b/src/language/locales/it/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "Questa transazione non andrà a buon fine a causa del movimento del prezzo o della commissione sul trasferimento. Prova ad aumentare la tolleranza allo slippage.",
   "To": "A",
   "To (estimated)": "A (stimato)",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "Per prelevare in SUSHI, visita Aave e rimuovi axSUSHI come collaterale, quindi visita SushiBar per togliere dallo staking. Un processo completo sarà presto disponibile.",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "Per prelevare in SUSHI, visita Aave e rimuovi axSUSHI come collaterale, quindi visita SushiBar per togliere dallo staking. Un processo completo sarà presto disponibile.",
   "Toggle Expert Mode": "Attiva modalità esperto",
   "Token": "Token",
   "Tokens": "Token",

--- a/src/language/locales/ja/catalog.json
+++ b/src/language/locales/ja/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "交換先",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "エキスパート モードへの切り替え",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/ko/catalog.json
+++ b/src/language/locales/ko/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "고급 설정",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/ro/catalog.json
+++ b/src/language/locales/ro/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "La",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "Comutare Modul Expert",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/ru/catalog.json
+++ b/src/language/locales/ru/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "До",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "Переключиться на экспертный режим",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/vi/catalog.json
+++ b/src/language/locales/vi/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "",
   "To": "Tới",
   "To (estimated)": "",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "",
   "Toggle Expert Mode": "",
   "Token": "",
   "Tokens": "",

--- a/src/language/locales/zh-CN/catalog.json
+++ b/src/language/locales/zh-CN/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "交易未成功，可能因为价格变动，也可能转账中产生的费用。请提高您可接受的滑点。",
   "To": "到",
   "To (estimated)": "至(估计)",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "撤回到SUSHI，去Aave把axSUSHI从质押品中移除，然后前往SushiBar解除质押。全流程即将在本网站启用。",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "撤回到SUSHI，去Aave把axSUSHI从质押品中移除，然后前往SushiBar解除质押。全流程即将在本网站启用。",
   "Toggle Expert Mode": "切换专家模式",
   "Token": "代币",
   "Tokens": "代币",

--- a/src/language/locales/zh-TW/catalog.json
+++ b/src/language/locales/zh-TW/catalog.json
@@ -256,7 +256,7 @@
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your slippage tolerance.": "交易未成功，可能因為價格變動，也可能轉賬中產生的費用。請提高您可接受的滑點。",
   "To": "到",
   "To (estimated)": "至(估計)",
-  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.": "撤回到SUSHI，去Aave把axSUSHI從質押品中移除，然後前往SushiBar解除質押。全流程即將在本網站啟用。",
+  "To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.": "撤回到SUSHI，去Aave把axSUSHI從質押品中移除，然後前往SushiBar解除質押。全流程即將在本網站啟用。",
   "Toggle Expert Mode": "切換專家模式",
   "Token": "代幣",
   "Tokens": "代幣",

--- a/src/pages/Saave/index.tsx
+++ b/src/pages/Saave/index.tsx
@@ -86,7 +86,7 @@ export default function Saave() {
                             <RowBetween>
                                 <TYPE.white fontSize={14} color={theme.text2}>
                                     {i18n._(
-                                        t`To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be avaialble soon.`
+                                        t`To withdraw into SUSHI, go to Aave and remove axSUSHI as collateral and then to SushiBar to unstake. A full unwind will be available soon.`
                                     )}
                                 </TYPE.white>
                             </RowBetween>


### PR DESCRIPTION
Fixed a typo: "avaialble" -> "available".

#131 was opened to fix this same issue, but didn't update the keys in all locales and hasn't had any updates for 5 days now.

