### PR TITLE
Fix arb explorer URLs

### DIFF
--- a/src/functions/explorer.ts
+++ b/src/functions/explorer.ts
@@ -82,7 +82,7 @@ const builders = {
         data: string,
         type: 'transaction' | 'token' | 'address' | 'block'
     ) => {
-        const prefix = `https://mainnet-arb-explorer.netlify.app/`
+        const prefix = `https://mainnet-arb-explorer.netlify.app`
         switch (type) {
             case 'transaction':
                 return `${prefix}/tx/${data}`

--- a/test/functions/explorer.test.ts
+++ b/test/functions/explorer.test.ts
@@ -31,5 +31,10 @@ describe('utils', () => {
                 'https://rinkeby.etherscan.io/address/abc'
             )
         })
+        it('arbitrum', () => {
+            expect(getExplorerLink(ChainId.ARBITRUM, 'abc', 'address')).toEqual(
+                'https://mainnet-arb-explorer.netlify.app/address/abc'
+            )
+        })
     })
 })


### PR DESCRIPTION
Fixes minor issue with mainnet-arb-explorer URLs.

Examples:

- **Before** (returns 404 due to double forward slash): https://mainnet-arb-explorer.netlify.app//address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1
- **After** (works): https://mainnet-arb-explorer.netlify.app/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1