### PR TITLE
remove z-index from add liquidity container

### DIFF
--- a/src/pages/add/[[...tokens]].tsx
+++ b/src/pages/add/[[...tokens]].tsx
@@ -415,7 +415,7 @@ export default function Add() {
                     {currencies[Field.CURRENCY_B]?.getSymbol(chainId)} POOL
                 </button> */}
             </div>
-            <div className="z-10 w-full max-w-2xl p-4 rounded bg-dark-900 shadow-liquidity">
+            <div className="w-full max-w-2xl p-4 rounded bg-dark-900 shadow-liquidity">
                 <Header
                     input={currencies[Field.CURRENCY_A]}
                     output={currencies[Field.CURRENCY_B]}


### PR DESCRIPTION
this z-index is causing it to overlay the notification popups in the top right.  it is not present on the corresponding remove/swap container components. 
![Screen Shot 2021-06-03 at 9 26 49 AM](https://user-images.githubusercontent.com/16813707/120854848-bb44cf00-c54b-11eb-9306-ef5810284ee8.jpg)
