### PR TITLE
use wallet_switchEthereumChain instead , to go back ETH

### DIFF
--- a/src/components/NetworkModal/index.tsx
+++ b/src/components/NetworkModal/index.tsx
@@ -198,7 +198,16 @@ export default function NetworkModal(): JSX.Element | null {
                 toggleNetworkModal()
                 const params = PARAMS[key]
                 cookie.set('chainId', key)
-                library?.send('wallet_addEthereumChain', [params, account])
+
+                if (ChainId.MAINNET == key) {
+                  library?.send("wallet_switchEthereumChain", [
+                    { chainId: "0x1" },
+                    account,
+                  ]);
+                } else {
+                  library?.send("wallet_addEthereumChain", [params, account]);
+                }
+                
               }}
               className="flex items-center w-full col-span-1 p-3 space-x-3 rounded cursor-pointer bg-dark-800 hover:bg-dark-700"
             >


### PR DESCRIPTION
To go back to ETH, we need wallet_switchEthereumChain instead of wallet_addEthereumChain. 

ref: https://github.com/MetaMask/metamask-extension/pull/10905

Cuz i don't have a github permission, will do PR without test perfectly. I've just tested on my local for my personal forked project. 

thanks