### PR TITLE
Stopgap fix to handle Infinity ROIs better in desc sort

### DIFF
--- a/src/hooks/useSortableData.ts
+++ b/src/hooks/useSortableData.ts
@@ -33,6 +33,10 @@ const useSortableData = (items: any, config: any = null) => {
             if (aValue.gt(bValue)) {
               return sortConfig.direction === 'ascending' ? 1 : -1
             }
+          } else if (aValue === Infinity) {
+            return sortConfig.direction === 'ascending' ? -1 : 1
+          } else if (bValue === Infinity) {
+            return sortConfig.direction === 'ascending' ? 1 : -1
           } else {
             if (aValue < bValue) {
               return sortConfig.direction === 'ascending' ? -1 : 1


### PR DESCRIPTION
Noticed that 2 1INCH farms had Infinity ROIs being calculated(see screenshot), and that they were sitting at the top of the list when ordered by highest APR first.. Since this is a deeper fix most likely, just considering this as a stopgap mitigation to ease confusion.

![Screenshot from 2021-07-08 12-39-32](https://user-images.githubusercontent.com/361323/124972311-cfb73400-dfef-11eb-8fa7-cf05af864077.png)