### PR TITLE
fix: take tip from returned amount when doing token -> eth

### DIFF
--- a/src/features/swap/ConfirmSwapModal.tsx
+++ b/src/features/swap/ConfirmSwapModal.tsx
@@ -86,7 +86,13 @@ export default function ConfirmSwapModal({
   } for ${trade?.outputAmount?.toSignificant(6)} ${trade?.outputAmount?.currency?.symbol}`
 
   const pendingText2 = minerBribe
-    ? `Plus ${CurrencyAmount.fromRawAmount(Ether.onChain(ChainId.MAINNET), minerBribe).toSignificant(6)} ETH Miner Tip`
+    ? trade?.outputAmount.currency.isNative
+      ? `Minus ${CurrencyAmount.fromRawAmount(Ether.onChain(ChainId.MAINNET), minerBribe).toSignificant(
+          6
+        )} ETH Miner Tip`
+      : `Plus ${CurrencyAmount.fromRawAmount(Ether.onChain(ChainId.MAINNET), minerBribe).toSignificant(
+          6
+        )} ETH Miner Tip`
     : undefined
 
   const confirmationContent = useCallback(

--- a/src/functions/archerRouter.ts
+++ b/src/functions/archerRouter.ts
@@ -107,7 +107,7 @@ export abstract class ArcherRouter {
         } else if (etherOut) {
           methodName = 'swapExactTokensForETHAndTipAmount'
           args = [factoryAddress, archerTrade, ethTip]
-          value = ethTip
+          value = '0x00'
         } else {
           methodName = 'swapExactTokensForTokensAndTipAmount'
           args = [factoryAddress, archerTrade]
@@ -122,7 +122,7 @@ export abstract class ArcherRouter {
         } else if (etherOut) {
           methodName = 'swapTokensForExactETHAndTipAmount'
           args = [factoryAddress, archerTrade, ethTip]
-          value = ethTip
+          value = '0x00'
         } else {
           methodName = 'swapTokensForExactTokensAndTipAmount'
           args = [factoryAddress, archerTrade]


### PR DESCRIPTION
When doing a token -> ETH trade using MEV Shield, take the tip from the returned ETH instead of requiring ETH from the user.