### PR TITLE
Add Pickle information for dual farming rewards

### DIFF
--- a/src/pages/farm/index.tsx
+++ b/src/pages/farm/index.tsx
@@ -15,6 +15,7 @@ import {
   useStakePrice,
   useSushiPairs,
   useSushiPrice,
+  usePicklePrice,
 } from '../../services/graph'
 
 import { ChainId } from '@sushiswap/sdk'
@@ -62,7 +63,7 @@ export default function Farm(): JSX.Element {
 
   // TODO: Obviously need to sort this out but this is fine for time being,
   // prices are only loaded when needed for a specific network
-  const [sushiPrice, ethPrice, maticPrice, alcxPrice, cvxPrice, stakePrice, onePrice] = [
+  const [sushiPrice, ethPrice, maticPrice, alcxPrice, cvxPrice, stakePrice, onePrice, picklePrice] = [
     useSushiPrice(),
     useEthPrice(),
     useMaticPrice(),
@@ -70,6 +71,7 @@ export default function Farm(): JSX.Element {
     useCvxPrice(),
     useStakePrice(),
     useOnePrice(),
+    usePicklePrice(),
   ]
 
   const blocksPerDay = 86400 / Number(averageBlockTime)
@@ -137,6 +139,13 @@ export default function Farm(): JSX.Element {
             rewardPerBlock: (pool.rewarder.rewardPerBlock / 1e18) * averageBlockTime,
             rewardPerDay: (pool.rewarder.rewardPerBlock / 1e18) * averageBlockTime * blocksPerDay,
             rewardPrice: cvxPrice,
+          },
+          {
+            token: 'PICKLE',
+            icon: 'https://raw.githubusercontent.com/sushiswap/icons/master/token/unknown.png',
+            rewardPerBlock: (pool.rewarder.rewardPerSecond / 1e18) * averageBlockTime,
+            rewardPerDay: (pool.rewarder.rewardPerSecond / 1e18) * averageBlockTime * blocksPerDay,
+            rewardPrice: picklePrice,
           },
         ]
 

--- a/src/services/graph/fetchers/exchange.ts
+++ b/src/services/graph/fetchers/exchange.ts
@@ -94,6 +94,12 @@ export const getAlcxPrice = async () => {
   })
 }
 
+export const getPicklePrice = async () => {
+  return getTokenPrice(ChainId.MAINNET, tokenPriceQuery, {
+    id: '0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5',
+  })
+}
+
 export const getSushiPrice = async () => {
   // console.log('getSushiPrice')
   return getTokenPrice(ChainId.MAINNET, tokenPriceQuery, {

--- a/src/services/graph/hooks/exchange.ts
+++ b/src/services/graph/hooks/exchange.ts
@@ -3,6 +3,7 @@ import {
   getAlcxPrice,
   getBundle,
   getCvxPrice,
+  getPicklePrice,
   getLiquidityPositions,
   getMaticPrice,
   getOnePrice,
@@ -75,6 +76,16 @@ export function useAlcxPrice(swrConfig: SWRConfiguration = undefined) {
 export function useCvxPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const { data } = useSWR(chainId && chainId === ChainId.MAINNET ? 'cvxPrice' : null, () => getCvxPrice(), swrConfig)
+  return data
+}
+
+export function usePicklePrice(swrConfig: SWRConfiguration = undefined) {
+  const { chainId } = useActiveWeb3React()
+  const { data } = useSWR(
+    chainId && chainId === ChainId.MAINNET ? 'picklePrice' : null,
+    () => getPicklePrice(),
+    swrConfig
+  )
   return data
 }
 


### PR DESCRIPTION
Note - the price of PICKLE (token address `0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5`) cannot be queried through the subgraph yet (as with the other tokens, e.g. CVX, ALCX).