### PR TITLE
fix: bentobox user balance display

### DIFF
--- a/src/pages/user/balances.tsx
+++ b/src/pages/user/balances.tsx
@@ -113,9 +113,9 @@ const TokenBalance = ({ token }: { token: BentoBalance & WrappedTokenInfo }) => 
             loader={cloudinaryLoader}
             height={56}
             width={56}
-            src={token.tokenInfo.logoURI}
+            src={token.tokenInfo?.logoURI}
             className="w-10 mr-4 rounded-lg sm:w-14"
-            alt={token.tokenInfo.symbol}
+            alt={token.tokenInfo?.symbol}
           />
           <div>{token && token.symbol}</div>
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12931494/127772161-2ccf5236-8e26-4964-a1ff-8b896d07a44d.png)
![image](https://user-images.githubusercontent.com/12931494/127772168-9e6da605-da03-48db-be0b-fdcd36cbbbd9.png)

seems some token does not have a tokenInfo property