### PR TITLE
Fix typo by removing extra '23' in slippage tooltip

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -1156,7 +1156,7 @@ msgstr "Ihre Transaktion könnte ein Front-Run-Handel sein."
 msgid "Your transaction may fail"
 msgstr "Ihre Transaktion kann fehlschlagen"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/en.po
+++ b/locale/en.po
@@ -1187,8 +1187,8 @@ msgstr "Your transaction may be frontrun"
 msgid "Your transaction may fail"
 msgstr "Your transaction may fail"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
-msgstr "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
+msgstr "Your transaction will revert if the price changes unfavorably by more than this percentage."
 
 msgid "Your transaction will revert if it is pending for more than this long."
 msgstr "Your transaction will revert if it is pending for more than this long."

--- a/locale/es-AR.po
+++ b/locale/es-AR.po
@@ -1174,7 +1174,7 @@ msgstr "Su transacción puede ser anticipada"
 msgid "Your transaction may fail"
 msgstr "Tu transacción puede fallar"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/es.po
+++ b/locale/es.po
@@ -1156,7 +1156,7 @@ msgstr "Su transacción podría ser una inversión ventajista"
 msgid "Your transaction may fail"
 msgstr "Su transacción podría fallar"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -1156,7 +1156,7 @@ msgstr "Votre transaction peut être en \"frontrun\""
 msgid "Your transaction may fail"
 msgstr "Votre transaction peut ne pas aboutir"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/it.po
+++ b/locale/it.po
@@ -1156,7 +1156,7 @@ msgstr "La tua transazione potrebbe essere anticipata"
 msgid "Your transaction may fail"
 msgstr "La tua transazione potrebbe fallire"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -1156,7 +1156,7 @@ msgstr "トランザクションはフロントランニングである可能性
 msgid "Your transaction may fail"
 msgstr "取引は失敗する可能性があります"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -1156,7 +1156,7 @@ msgstr "거래가 프론트러닝될 수 있습니다"
 msgid "Your transaction may fail"
 msgstr "거래가 실패할 수 있습니다"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -1156,7 +1156,7 @@ msgstr "Tranzacția dvs. poate fi favorită"
 msgid "Your transaction may fail"
 msgstr "Tranzacția dvs. poate eșua"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -1156,7 +1156,7 @@ msgstr "Ваша транзакция может быть авансирован
 msgid "Your transaction may fail"
 msgstr "Ваша транзакция может завершиться неудачно"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -1156,7 +1156,7 @@ msgstr "Giao dịch của bạn có thể chạy trước"
 msgid "Your transaction may fail"
 msgstr "Giao dịch của bạn có thể thất bại"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/zh-CN.po
+++ b/locale/zh-CN.po
@@ -1156,7 +1156,7 @@ msgstr "您的交易可能被抢跑。"
 msgid "Your transaction may fail"
 msgstr "您的交易可能失败。"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/locale/zh-TW.po
+++ b/locale/zh-TW.po
@@ -1156,7 +1156,7 @@ msgstr "您的交易可能被搶跑。"
 msgid "Your transaction may fail"
 msgstr "您的交易可能失敗。"
 
-msgid "Your transaction will revert 23if the price changes unfavorably by more than this percentage."
+msgid "Your transaction will revert if the price changes unfavorably by more than this percentage."
 msgstr ""
 
 msgid "Your transaction will revert if it is pending for more than this long."

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -96,7 +96,7 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
 
           <QuestionHelper
             text={i18n._(
-              t`Your transaction will revert 23if the price changes unfavorably by more than this percentage.`
+              t`Your transaction will revert if the price changes unfavorably by more than this percentage.`
             )}
           />
         </div>


### PR DESCRIPTION
Looks like a fairly recent typo.