### PR TITLE
[REFACTOR]: use of headless-ui tabs in place of react-tabs and drop dependency of react-tabs 

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "react-redux": "^7.2.4",
     "react-spring": "^8.0.27",
     "react-table": "^7.7.0",
-    "react-tabs": "^3.2.2",
     "react-test-renderer": "^17.0.2",
     "react-use-gesture": "^9.1.3",
     "react-virtualized": "^9.22.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@ethersproject/providers": "^5.4.0",
     "@fontsource/dm-sans": "^4.5.0",
     "@gnosis.pm/safe-apps-web3-react": "^0.6.0",
-    "@headlessui/react": "^1.3.0",
+    "@headlessui/react": "^1.4.0",
     "@heroicons/react": "^1.0.2",
     "@keystonehq/keystone-connector": "^0.8.0",
     "@lingui/cli": "^3.10.2",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,7 +2,6 @@ import '../bootstrap'
 import '../styles/index.css'
 import '@fontsource/dm-sans/index.css'
 import 'react-virtualized/styles.css'
-import 'react-tabs/style/react-tabs.css'
 import 'rc-slider/assets/index.css'
 
 import * as plurals from 'make-plural/plurals'

--- a/src/pages/kashi/borrow/[pair].tsx
+++ b/src/pages/kashi/borrow/[pair].tsx
@@ -26,7 +26,6 @@ import { useV2Pair } from '../../../hooks/useV2Pairs'
 function Pair() {
   const router = useRouter()
   const { i18n } = useLingui()
-  const [tabIndex, setTabIndex] = useState(0)
 
   const { account, library, chainId } = useActiveWeb3React()
 
@@ -126,29 +125,23 @@ function Pair() {
             </div>
           </div>
         </div>
-        <Tab.Group
-        // forceRenderTabPanel selectedIndex={tabIndex} onSelect={(index: number) => setTabIndex(index)}
-        >
+        <Tab.Group>
           <Tab.List className="flex p-1 rounded bg-dark-800">
             <Tab
-              // className={}
               className={({ selected }) =>
                 `${
                   selected ? 'bg-dark-900 text-high-emphesis' : ''
                 } flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none`
               }
-              // selectedClassName="bg-dark-900 text-high-emphesis"
             >
               {i18n._(t`Borrow`)}
             </Tab>
             <Tab
-              // className={}
               className={({ selected }) =>
                 `${
                   selected ? 'bg-dark-900 text-high-emphesis' : ''
                 } flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none`
               }
-              // selectedClassName="bg-dark-900 text-high-emphesis"
             >
               {i18n._(t`Repay`)}
             </Tab>

--- a/src/pages/kashi/borrow/[pair].tsx
+++ b/src/pages/kashi/borrow/[pair].tsx
@@ -1,7 +1,7 @@
 import { Borrow, Repay } from '../../../features/lending'
 import Provider, { useKashiInfo, useKashiPair } from '../../../features/lending/context'
 import React, { useCallback, useState } from 'react'
-import { Tab, TabList, TabPanel, Tabs } from 'react-tabs'
+import { Tab } from '@headlessui/react'
 import { formatNumber, formatPercent } from '../../../functions/format'
 
 import { BorrowCardHeader } from '../../../components/CardHeader'
@@ -126,28 +126,40 @@ function Pair() {
             </div>
           </div>
         </div>
-        <Tabs forceRenderTabPanel selectedIndex={tabIndex} onSelect={(index: number) => setTabIndex(index)}>
-          <TabList className="flex p-1 rounded bg-dark-800">
+        <Tab.Group
+        // forceRenderTabPanel selectedIndex={tabIndex} onSelect={(index: number) => setTabIndex(index)}
+        >
+          <Tab.List className="flex p-1 rounded bg-dark-800">
             <Tab
-              className="flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none"
-              selectedClassName="bg-dark-900 text-high-emphesis"
+              // className={}
+              className={({ selected }) =>
+                `${
+                  selected ? 'bg-dark-900 text-high-emphesis' : ''
+                } flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none`
+              }
+              // selectedClassName="bg-dark-900 text-high-emphesis"
             >
               {i18n._(t`Borrow`)}
             </Tab>
             <Tab
-              className="flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none"
-              selectedClassName="bg-dark-900 text-high-emphesis"
+              // className={}
+              className={({ selected }) =>
+                `${
+                  selected ? 'bg-dark-900 text-high-emphesis' : ''
+                } flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none`
+              }
+              // selectedClassName="bg-dark-900 text-high-emphesis"
             >
               {i18n._(t`Repay`)}
             </Tab>
-          </TabList>
-          <TabPanel>
+          </Tab.List>
+          <Tab.Panel>
             <Borrow pair={pair} />
-          </TabPanel>
-          <TabPanel>
+          </Tab.Panel>
+          <Tab.Panel>
             <Repay pair={pair} />
-          </TabPanel>
-        </Tabs>
+          </Tab.Panel>
+        </Tab.Group>
       </Card>
     </>
   )

--- a/src/pages/kashi/lend/[pair].tsx
+++ b/src/pages/kashi/lend/[pair].tsx
@@ -19,7 +19,6 @@ import { useRouter } from 'next/router'
 export default function Pair() {
   const router = useRouter()
   const { i18n } = useLingui()
-  const [tabIndex, setTabIndex] = useState(0)
 
   const pair = useKashiPair(router.query.pair as string)
   const info = useKashiInfo()

--- a/src/pages/kashi/lend/[pair].tsx
+++ b/src/pages/kashi/lend/[pair].tsx
@@ -1,7 +1,7 @@
 import { Deposit, Withdraw } from '../../../features/lending'
 import Provider, { useKashiInfo, useKashiPair } from '../../../features/lending/context'
 import React, { useState } from 'react'
-import { Tab, TabList, TabPanel, Tabs } from 'react-tabs'
+import { Tab } from '@headlessui/react'
 import { formatNumber, formatPercent } from '../../../functions/format'
 
 import Card from '../../../components/Card'
@@ -96,28 +96,34 @@ export default function Pair() {
           </div>
         </div>
 
-        <Tabs forceRenderTabPanel selectedIndex={tabIndex} onSelect={(index: number) => setTabIndex(index)}>
-          <TabList className="flex p-1 rounded bg-dark-800">
+        <Tab.Group>
+          <Tab.List className="flex p-1 rounded bg-dark-800">
             <Tab
-              className="flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none"
-              selectedClassName="bg-dark-900 text-high-emphesis"
+              className={({ selected }) =>
+                `${
+                  selected ? 'bg-dark-900 text-high-emphesis' : ''
+                } flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none`
+              }
             >
               {i18n._(t`Deposit`)} {pair.asset.tokenInfo.symbol}
             </Tab>
             <Tab
-              className="flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none"
-              selectedClassName="bg-dark-900 text-high-emphesis"
+              className={({ selected }) =>
+                `${
+                  selected ? 'bg-dark-900 text-high-emphesis' : ''
+                } flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none`
+              }
             >
               {i18n._(t`Withdraw`)} {pair.asset.tokenInfo.symbol}
             </Tab>
-          </TabList>
-          <TabPanel>
+          </Tab.List>
+          <Tab.Panel>
             <Deposit pair={pair} />
-          </TabPanel>
-          <TabPanel>
+          </Tab.Panel>
+          <Tab.Panel>
             <Withdraw pair={pair} />
-          </TabPanel>
-        </Tabs>
+          </Tab.Panel>
+        </Tab.Group>
       </Card>
     </div>
   )

--- a/src/pages/status/index.tsx
+++ b/src/pages/status/index.tsx
@@ -1,4 +1,4 @@
-import { Tab, TabList, TabPanel, Tabs } from 'react-tabs'
+import { Tab } from '@headlessui/react'
 
 import Container from '../../components/Container'
 import Dots from '../../components/Dots'
@@ -11,9 +11,8 @@ import { useChainsStatus } from '../../services/covalent/hooks'
 import { useState } from 'react'
 
 export default function Status({ initialData }) {
-  // const res = useChainsStatus({ initialData })
-  // const [tabIndex, setTabIndex] = useState(0)
-  // const { data } = res.data
+  //   const res = useChainsStatus({ initialData })
+  //   const { data } = res.data
   return (
     <Container id="status-page" className="py-4 md:py-8 lg:py-12" maxWidth="full">
       <Head>
@@ -25,71 +24,58 @@ export default function Status({ initialData }) {
                     Status
                 </Typography>
 
-                <Tabs
-                    selectedIndex={tabIndex}
-                    onSelect={(index) => setTabIndex(index)}
-                    selectedTabClassName="bg-none"
-                >
-                    <TabList className="flex">
-                        <Tab
-                            className={classNames(
-                                tabIndex !== 0 &&
-                                    'text-gray-500 hover:text-gray-700',
-                                'py-4 px-4 text-center font-medium text-sm cursor-pointer'
-                            )}
-                        >
-                            Covalent
-                        </Tab>
-                        <Tab
-                            className={classNames(
-                                tabIndex !== 1 &&
-                                    'text-gray-500 hover:text-gray-700',
-                                'py-4 px-4 text-center font-medium text-sm cursor-pointer'
-                            )}
-                        >
-                            Subgraph
-                        </Tab>
-                    </TabList>
-                    <TabPanel>
-                        <div className="grid items-start justify-start grid-cols-3 gap-4 mx-auto ">
-                            {data.items.map((item) => {
-                                const words = item.name.split('-')
-                                return (
-                                    <div className="p-4 rounded bg-dark-900 text-primary">
-                                        <Typography variant="h3">
-                                            {words.map(
-                                                (word) => `${capitalize(word)} `
-                                            )}
-                                        </Typography>
-                                        <Typography
-                                            variant="sm"
-                                            className="text-secondary"
-                                        >
-                                            Chain Id: {item['chain_id']}
-                                        </Typography>
-                                        <Typography
-                                            variant="sm"
-                                            className="text-secondary"
-                                        >
-                                            Block Height:{' '}
-                                            {item['synced_block_height']}
-                                        </Typography>
-                                    </div>
-                                )
-                            })}
-                        </div>
-                    </TabPanel>
-                    <TabPanel>
-                        <div className="grid items-start justify-start grid-cols-3 gap-4 mx-auto ">
-                            <div className="p-4 text-primary">
-                                <Typography variant="h3">
-                                    <Dots>Under Construction</Dots>
-                                </Typography>
-                            </div>
-                        </div>
-                    </TabPanel>
-                </Tabs>
-            </div> */}
+        <Tab.Group>
+          <Tab.List className="flex">
+            <Tab
+              className={({ selected }) =>
+                classNames(
+                  !selected && 'text-gray-500 hover:text-gray-700',
+                  'py-4 px-4 text-center font-medium text-sm cursor-pointer'
+                )
+              }
+            >
+              Covalent
+            </Tab>
+            <Tab
+              className={({ selected }) =>
+                classNames(
+                  !selected && 'text-gray-500 hover:text-gray-700',
+                  'py-4 px-4 text-center font-medium text-sm cursor-pointer'
+                )
+              }
+            >
+              Subgraph
+            </Tab>
+          </Tab.List>
+          <Tab.Panel>
+            <div className="grid items-start justify-start grid-cols-3 gap-4 mx-auto ">
+              {data.items.map((item) => {
+                const words = item.name.split('-')
+                return (
+                  <div className="p-4 rounded bg-dark-900 text-primary">
+                    <Typography variant="h3">{words.map((word) => `${capitalize(word)} `)}</Typography>
+                    <Typography variant="sm" className="text-secondary">
+                      Chain Id: {item['chain_id']}
+                    </Typography>
+                    <Typography variant="sm" className="text-secondary">
+                      Block Height: {item['synced_block_height']}
+                    </Typography>
+                  </div>
+                )
+              })}
+            </div>
+          </Tab.Panel>
+          <Tab.Panel>
+            <div className="grid items-start justify-start grid-cols-3 gap-4 mx-auto ">
+              <div className="p-4 text-primary">
+                <Typography variant="h3">
+                  <Dots>Under Construction</Dots>
+                </Typography>
+              </div>
+            </div>
+          </Tab.Panel>
+        </Tab.Group>
+            </div>*/}
 
       {/* <pre>{JSON.stringify(data, null, 2)}</pre> */}
     </Container>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2,7 +2,6 @@
 
 /* @import '@fontsource/dm-sans/index.css';
 @import 'react-virtualized/styles.css';
-@import 'react-tabs/style/react-tabs.css';
 @import 'rc-slider/assets/index.css'; */
 
 @import './variables.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1759,7 +1759,7 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@headlessui/react@^1.3.0":
+"@headlessui/react@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.4.0.tgz#c6d424d8ab10ac925e4423d7f3cbab02c30d736a"
   integrity sha512-C+FmBVF6YGvqcEI5fa2dfVbEaXr2RGR6Kw1E5HXIISIZEfsrH/yuCgsjWw5nlRF9vbCxmQ/EKs64GAdKeb8gCw==


### PR DESCRIPTION
Hey @matthewlilley ,
This PR includes the use of headless-ui tabs in place of react-tabs and dropping the react-tabs dependency. Changes has been done on `src/pages/kashi/borrow/[pair].tsx` and `src/pages/kashi/lend/[pair].tsx` pages. Also, on `src/pages/status/index.tsx` which is still under construction.

Also, I have updated the version of `headless-ui` we use from `1.3.0` to `1.4.0`.

Thank you.
Related to #289 