### PR TITLE
fix: update add route in PositionCard

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -238,7 +238,7 @@ export default function FullPositionCard({ pair, border, stakedBalance }: Positi
               <Button
                 color="blue"
                 onClick={() => {
-                  router.push(`/add/${pair.liquidityToken.address}`)
+                  router.push(`/add/${currencyId(currency0)}/${currencyId(currency1)}`)
                 }}
               >
                 {i18n._(t`Add`)}


### PR DESCRIPTION
Currently the add button is routing to /add/pairaddress but it should be /add/token0/token1