### PR TITLE
fix(calcs): fix APR/APY calculation 

### DIFF
--- a/src/functions/convert/apyApr.ts
+++ b/src/functions/convert/apyApr.ts
@@ -1,7 +1,26 @@
-// From https://gist.github.com/sterlu/4b44f59ea665819974ae684d7f564d9b
+// original implementation: https://gist.github.com/sterlu/4b44f59ea665819974ae684d7f564d9b
 
-const SECONDS_PER_YEAR = 365.25 * 24 * 60 * 60
-const BLOCKS_IN_A_YEAR = SECONDS_PER_YEAR / 14
+
+// @NOTE 
+//  A four-century period will be missing 3 of its 100 Julian leap years, leaving 97.
+//      So the average year has 365 + 97/400 = 365.2425 days
+//      ERROR RATE (Julian): -0.0078 = 365.25
+//      ERROR RATE (Gregorian): -0.0003 = 365.2425
+//      A Day = 24 * 60 * 60 sec = 86400 sec
+//      (Gregorian): 365.2425 * 86400 = 31556952.0
+// see https://github.com/yearn/yearn-vaults/blob/912e04db254c6c3b4ea420a97fe42495c4d5343a/contracts/Vault.vy#L235
+
+const SECONDS_PER_YEAR = 365.2425 * 86400  /** SECONDS_PER_YEAR = 31,556,952 */
+
+/** 
+* London / Berlin / Muir Glacier Block Speed 
+* AVERAGE: 13.2
+* MEDIAN: 13.21475904
+* Source: https://openmev.page.link/block-delta
+* @NOTE: We round up due to an observed increase in block prop. from Muir Glacier <> Berlin vs. Berlin <> London
+*/
+
+const BLOCKS_IN_A_YEAR = SECONDS_PER_YEAR / 13.25
 
 /**
  * Formula source: http://www.linked8.com/blog/158-apy-to-apr-and-apr-to-apy-calculation-methodologies


### PR DESCRIPTION
this fixes the calendar system to use the proper constants. It also decreases the observed `BLOCKS_IN_A_YEAR` value to take into account only post Muir-Glacier block speeds.


TLDR: This reduces over-reporting APY/APR rates 