### PR TITLE
Add bridge to go out of AVAX

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -64,7 +64,7 @@ const Footer = () => {
         )}
 
         {chainId && chainId === ChainId.AVALANCHE && (
-          <ExternalLink id={`avalanche-bridge-link`} href=" hhttps://app.relaychain.com/#/cross-chain-bridge-transfer" className="text-low-emphesis">
+          <ExternalLink id={`avalanche-bridge-link`} href=" https://app.relaychain.com/#/cross-chain-bridge-transfer" className="text-low-emphesis">
             {i18n._(t`Relaychain AVAX Bridge`)}
           </ExternalLink>
         )}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -64,7 +64,7 @@ const Footer = () => {
         )}
 
         {chainId && chainId === ChainId.AVALANCHE && (
-          <ExternalLink id={`palm-bridge-link`} href=" hhttps://app.relaychain.com/#/cross-chain-bridge-transfer" className="text-low-emphesis">
+          <ExternalLink id={`avalanche-bridge-link`} href=" hhttps://app.relaychain.com/#/cross-chain-bridge-transfer" className="text-low-emphesis">
             {i18n._(t`Relaychain AVAX Bridge`)}
           </ExternalLink>
         )}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -63,6 +63,12 @@ const Footer = () => {
           </ExternalLink>
         )}
 
+        {chainId && chainId === ChainId.AVAX && (
+          <ExternalLink id={`palm-bridge-link`} href=" hhttps://app.relaychain.com/#/cross-chain-bridge-transfer" className="text-low-emphesis">
+            {i18n._(t`Relaychain AVAX Bridge`)}
+          </ExternalLink>
+        )}
+        
         <Polling />
       </div>
     </footer>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -63,7 +63,7 @@ const Footer = () => {
           </ExternalLink>
         )}
 
-        {chainId && chainId === ChainId.AVAX && (
+        {chainId && chainId === ChainId.AVALANCHE && (
           <ExternalLink id={`palm-bridge-link`} href=" hhttps://app.relaychain.com/#/cross-chain-bridge-transfer" className="text-low-emphesis">
             {i18n._(t`Relaychain AVAX Bridge`)}
           </ExternalLink>


### PR DESCRIPTION
Easy and secure bridge (triple audited) to go out of AVAX, to poly, moonriver, bsc, heco, eth, shiden etc.