### PR TITLE
fix(deps): pin walletconnect version

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@web3-react/portis-connector": "^6.1.9",
     "@web3-react/torus-connector": "^6.1.9",
     "@web3-react/walletconnect-connector": "7.0.2-alpha.0",
-    "@web3-react/walletlink-connector": "^6.2.3",
+    "@web3-react/walletlink-connector": "6.2.3",
     "@welldone-software/why-did-you-render": "^6.2.0",
     "autoprefixer": "^10.3.1",
     "babel-jest": "^27.2.0",


### PR DESCRIPTION
versions 6.2.4-6.2.6 are DOA on npm, this is the last working release of this release (6.x.x)

See issues: 
- https://github.com/NoahZinsmeister/web3-react/issues/297
- https://github.com/NoahZinsmeister/web3-react/issues/298
- https://github.com/NoahZinsmeister/web3-react/issues/295