### PR TITLE
fix for invalid "\n" showing on the i18n rendered

### DIFF
--- a/src/pages/bar/index.tsx
+++ b/src/pages/bar/index.tsx
@@ -196,7 +196,7 @@ export default function Stake() {
                                 proportional to your share of the SushiBar. When your SUSHI is staked into the SushiBar, you receive
                                 xSUSHI in return for voting rights and a fully composable token that can interact with other protocols.
                                 Your xSUSHI is continuously compounding, when you unstake you will receive all the originally deposited
-                                SUSHI and any additional from fees.`)}
+                                SUSHI and any additional from fees.`).split("\n").join(" ")}
             </div>
             {/* <div className="flex">
                             <div className="mr-14 md:mr-9">


### PR DESCRIPTION
on the https://app.sushi.com/stake page
additional "\n" are appended onto the first description paragraph e.g.(SUSHI\nproportional):

"For every swap on the exchange on every chain, 0.05% of the swap fees are distributed as SUSHI\nproportional to your share of the SushiBar. "