### PR TITLE
fix: Enable network switcher menu for Coinbase Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@web3-react/portis-connector": "^6.1.9",
     "@web3-react/torus-connector": "^6.1.9",
     "@web3-react/walletconnect-connector": "^6.2.8",
-    "@web3-react/walletlink-connector": "^6.2.3",
+    "@web3-react/walletlink-connector": "^6.2.8",
     "@welldone-software/why-did-you-render": "^6.2.0",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-styled-components": "^1.13.1",

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,6 @@
 import { ChainId, Currency, NATIVE, SUSHI_ADDRESS } from '@sushiswap/sdk'
+import { InjectedConnector } from '@web3-react/injected-connector'
+import { WalletLinkConnector } from '@web3-react/walletlink-connector'
 import React, { useEffect, useState } from 'react'
 
 import { ANALYTICS_URL } from '../../constants'
@@ -23,7 +25,12 @@ import { useLingui } from '@lingui/react'
 
 function AppBar(): JSX.Element {
   const { i18n } = useLingui()
-  const { account, chainId, library } = useActiveWeb3React()
+  const { account, chainId, library, connector } = useActiveWeb3React()
+
+  const isCbWallet =
+    connector instanceof WalletLinkConnector ||
+    (connector instanceof InjectedConnector && window.walletLinkExtension) ||
+    window?.ethereum?.isCoinbaseWallet
 
   const userEthBalance = useETHBalances(account ? [account] : [])?.[account ?? '']
 
@@ -223,7 +230,7 @@ function AppBar(): JSX.Element {
                       </>
                     )}
 
-                    {library && library.provider.isMetaMask && (
+                    {library && (library.provider.isMetaMask || isCbWallet) && (
                       <div className="hidden sm:inline-block">
                         <Web3Network />
                       </div>

--- a/sushi-env.d.ts
+++ b/sushi-env.d.ts
@@ -8,7 +8,9 @@ declare global {
     toBigNumber(decimals: number): BigNumber
   }
   interface Window {
+    walletLinkExtension?: any
     ethereum?: {
+      isCoinbaseWallet?: true
       isMetaMask?: true
       on?: (...args: any[]) => void
       removeListener?: (...args: any[]) => void

--- a/yarn.lock
+++ b/yarn.lock
@@ -3575,14 +3575,14 @@
     "@web3-react/types" "^6.0.7"
     tiny-invariant "^1.0.6"
 
-"@web3-react/walletlink-connector@^6.2.3":
-  version "6.2.7"
-  resolved "https://registry.yarnpkg.com/@web3-react/walletlink-connector/-/walletlink-connector-6.2.7.tgz#f8c63556d1ddd569b88e0f27390b362e60dece3f"
-  integrity sha512-FW/+03XpDLFT3ZCJZzAV5pgqKnbDWkqy85bOyA4iHDMkWAo1Y1yz7M6y9GkYTipzKHO2IEn5zbP7XXwOzOxLZA==
+"@web3-react/walletlink-connector@^6.2.8":
+  version "6.2.8"
+  resolved "https://registry.yarnpkg.com/@web3-react/walletlink-connector/-/walletlink-connector-6.2.8.tgz#aaf7f413229f58d8087a15e0d049bbcbe5e0bd49"
+  integrity sha512-pSGufPz5JntSUvy88XcOrn5VN3qmX+ZVQ2lXAeWWb7YS2wTlAStPghZbln8t1li7jr1NUJ0w/gMDVpAwjwq4ZA==
   dependencies:
     "@web3-react/abstract-connector" "^6.0.7"
     "@web3-react/types" "^6.0.7"
-    walletlink "^2.1.11"
+    walletlink "^2.2.6"
 
 "@welldone-software/why-did-you-render@^6.2.0":
   version "6.2.1"
@@ -5185,14 +5185,6 @@ buffer@^5.0.5, buffer@^5.1.0, buffer@^5.2.0, buffer@^5.2.1, buffer@^5.4.2, buffe
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
-
-buffer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
-  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.2.1"
 
 bufferutil@^4.0.1:
   version "4.0.5"
@@ -9110,7 +9102,7 @@ idna-uts46-hx@^2.3.1:
   dependencies:
     punycode "2.1.0"
 
-ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -15562,7 +15554,7 @@ util.promisify@^1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.1"
 
-util@0.12.4, util@^0.12.0, util@^0.12.4:
+util@0.12.4, util@^0.12.0:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
   integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
@@ -15646,15 +15638,14 @@ walkdir@^0.4.1:
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.4.1.tgz#dc119f83f4421df52e3061e514228a2db20afa39"
   integrity sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==
 
-walletlink@^2.1.11:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/walletlink/-/walletlink-2.1.11.tgz#4ed5d53066f4fae8cc43169475e4f9d1f6b8735a"
-  integrity sha512-DdnQ2jnVHAdKgQ1IgxPKn3GvVEUbrGCgvgqKqQ7eanxUnyWgRm5T8Ib6NqPDuQ6SNFk6St54uN+uxV7GP6AyZg==
+walletlink@^2.2.6:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/walletlink/-/walletlink-2.4.0.tgz#9cfc3d038b2c40b87433fb1719dec8551aef81c1"
+  integrity sha512-JAYRdbmqEqh+kTFlhEezyGwcn3e8WiDyORXWB8odnvP9+leKIsjO3RW8VoZKR86+m4TY9OsUMcx4w+B7mYxg6g==
   dependencies:
     "@metamask/safe-event-emitter" "2.0.0"
     bind-decorator "^1.0.11"
     bn.js "^5.1.1"
-    buffer "^6.0.3"
     clsx "^1.1.0"
     eth-block-tracker "4.4.3"
     eth-json-rpc-filters "4.2.2"
@@ -15665,7 +15656,6 @@ walletlink@^2.1.11:
     preact "^10.5.9"
     rxjs "^6.6.3"
     stream-browserify "^3.0.0"
-    util "^0.12.4"
 
 warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
Enables the 3085 network switcher menu for Coinbase Wallet (dapp browser in mobile app, walletlink via mobile device, and walletlink via Coinbase Wallet chromium extension). Also updates walletlink-connector to a version that supports 3085 requests.

Prior PR into canary at
https://github.com/sushiswap/sushiswap-interface/pull/420

Equivalent PR into uniswap
https://github.com/Uniswap/interface/pull/2753