### PR TITLE
Add Banxa iframe to sushiswap interface

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,6 +3,7 @@ import { Feature, featureEnabled } from '../../functions/feature'
 import React from 'react'
 
 import { ANALYTICS_URL } from '../../constants'
+import BuyBanxaButton from '../../features/on-ramp/banxa'
 import Buy from '../../features/on-ramp/ramp'
 import ExternalLink from '../ExternalLink'
 import Image from 'next/image'
@@ -40,6 +41,7 @@ function AppBar(): JSX.Element {
                   <div className="hidden sm:block sm:ml-4">
                     <div className="flex space-x-2">
                       {/* <Buy /> */}
+                      <BuyBanxaButton />
                       <NavLink href="/swap">
                         <a
                           id={`swap-nav-link`}

--- a/src/features/on-ramp/banxa/index.tsx
+++ b/src/features/on-ramp/banxa/index.tsx
@@ -1,0 +1,32 @@
+import { t } from '@lingui/macro'
+import { useCallback } from 'react'
+import { useLingui } from '@lingui/react'
+import React, { useState } from 'react';
+import Modal from '../../../components/Modal'
+
+
+export default function Buy() {
+  const [isActive, setActive] = useState(false);
+
+  const toggleModal = () => {
+    setActive(!isActive);
+  };
+
+  const { i18n } = useLingui() 
+
+  return (
+    <>
+      <a
+        id={`buy-link`}
+        onClick={toggleModal}
+        className="p-2 cursor-pointer text-baseline text-primary hover:text-high-emphesis focus:text-high-emphesis md:p-3 whitespace-nowrap"
+      >
+        {i18n._(t`Buy`)}
+      </a>
+      <Modal isOpen={isActive} onDismiss={toggleModal}>
+        <iframe loading="lazy" src="https://sushiswap.banxa.com/iframe?code=chBbK8X8yHkbkHt3Lihi" scrolling="yes" allowtransparency="true" id="widget-buy" width="100%" height="650px" frameBorder="0"></iframe>
+      </Modal>
+      
+    </>
+  )
+}


### PR DESCRIPTION
# Sushiswap X Banxa

## Context
Integrating Banxa's on-ramp flow with Sushiswap to further Banxa's ongoing support for direct fiat payments to a range of L2 protocols, including Arbitrum, Optimism, zkSync, Loopring with more coming in January.

## Updates
- Integrated Banxa iframe into Sushiswap modal
- Added Banxa buy button within header component for demonstration
- Added new folder (Banxa) within on-ramps folder
