### PR TITLE
CI Fix: dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,19 @@
-version: 1
+version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
-    # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'daily'
+    commit-message:
+      # Prefix all commit messages with "npm"
+      prefix: 'token list'
+      include: 'scope'
+    labels:
+      - 'tokenlist'
+      # Add default Kodiak `merge.automerge_label`
+      #- 'automerge'
     allow:
       - dependency-name: '@sushiswap/default-token-list'
       - dependency-name: '@sushiswap/limit-order-pair-list'
+#    assignees:
+#      - "octocat"


### PR DESCRIPTION
version: 1 of dependabot is depreciated and no longer working, this fixes the version to 2 and adds a label and commit message as well