### PR TITLE
feat: Typescript STRICT mode enabled

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -74,6 +74,7 @@ const AccountDetails: FC<AccountDetailsProps> = ({
               <div className="overflow-hidden rounded-full">
                 <Davatar
                   size={48}
+                  // @ts-ignore TYPE NEEDS FIXING
                   address={account}
                   defaultComponent={<Image src="/images/chef.svg" alt="Sushi Chef" width={48} height={48} />}
                   provider={library}

--- a/src/components/AddressInputPanel/index.tsx
+++ b/src/components/AddressInputPanel/index.tsx
@@ -26,6 +26,7 @@ const AddressInputPanel: FC<AddressInputPanelProps> = ({ id, value, onChange }) 
     >
       <div className="flex justify-between w-full px-5 sm:w-2/5">
         <span className="text-[18px] text-primary">{i18n._(t`Send to:`)}</span>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <span className="text-sm underline cursor-pointer text-blue" onClick={() => onChange(null)}>
           {i18n._(t`Remove`)}
         </span>

--- a/src/components/AssetInput/index.tsx
+++ b/src/components/AssetInput/index.tsx
@@ -80,6 +80,7 @@ const AssetInput: AssetInput<AssetInputProps> = ({ spendFromWallet = true, class
               <CurrencySearchModal.Controlled
                 open={open}
                 selectedCurrency={props.currency}
+                // @ts-ignore TYPE NEEDS FIXING
                 onCurrencySelect={props.onSelect}
                 onDismiss={() => setOpen(false)}
                 currencyList={props.currencies}
@@ -180,6 +181,7 @@ const AssetInputPanel = ({
               </div>
             }
             selectedCurrency={currency}
+            // @ts-ignore TYPE NEEDS FIXING
             onCurrencySelect={onSelect}
             currencyList={currencies}
           />

--- a/src/components/BarGraph/index.tsx
+++ b/src/components/BarGraph/index.tsx
@@ -2,6 +2,7 @@ import { Group } from '@visx/group'
 import { scaleBand, scaleLinear } from '@visx/scale'
 import { Bar } from '@visx/shape'
 import React, { FC, useMemo } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import AutoSizer from 'react-virtualized-auto-sizer'
 
 const verticalMargin = 40
@@ -70,8 +71,11 @@ const Graph: FC<BarGraphProps> = ({ data, width, height, setSelectedDatum, event
               width={barWidth}
               height={barHeight}
               fill="rgba(0, 160, 233, 1)"
+              // @ts-ignore TYPE NEEDS FIXING
               onClick={() => setSelectedDatum(d)}
+              // @ts-ignore TYPE NEEDS FIXING
               onMouseMove={() => setSelectedDatum(d)}
+              // @ts-ignore TYPE NEEDS FIXING
               onMouseEnter={() => setSelectedDatum(d)}
             />
           )
@@ -81,6 +85,8 @@ const Graph: FC<BarGraphProps> = ({ data, width, height, setSelectedDatum, event
   )
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const BarGraph = ({ data, ...rest }) => (
+  // @ts-ignore TYPE NEEDS FIXING
   <AutoSizer>{({ width, height }) => <Graph data={data} width={width} height={height} {...rest} />}</AutoSizer>
 )

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -94,8 +94,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         className={classNames(
           VARIANT[variant]['default'],
+          // @ts-ignore TYPE NEEDS FIXING
           VARIANT[variant][color],
+          // @ts-ignore TYPE NEEDS FIXING
           SIZE[size],
+          // @ts-ignore TYPE NEEDS FIXING
           variant !== 'empty' ? DIMENSIONS[size] : '',
           fullWidth ? 'w-full' : '',
           'font-bold flex items-center justify-center gap-1',

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,6 +1,7 @@
 import { classNames } from 'app/functions/styling'
 import React, { FC } from 'react'
 
+// @ts-ignore TYPE NEEDS FIXING
 function Header({ className, children }) {
   return (
     <div className={classNames('flex items-center rounded-t px-4 sm:px-8 py-4 sm:py-6', className)}>{children}</div>

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -59,6 +59,7 @@ export const Purple = Template.bind({})
 Purple.args = {
   color: 'purple',
   label: 'Classic Pool',
+  // @ts-ignore TYPE NEEDS FIXING
   onClick: null,
 }
 
@@ -91,5 +92,6 @@ export const White = Template.bind({})
 White.args = {
   color: 'white',
   label: '70%',
+  // @ts-ignore TYPE NEEDS FIXING
   onClick: null,
 }

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -34,6 +34,7 @@ export interface ChipProps {
   variant?: ChipVariant
   size?: ChipSize
   className?: string
+  // @ts-ignore TYPE NEEDS FIXING
   onClick?: (e) => void
   icon?: ReactNode
   endIcon?: ReactNode

--- a/src/components/CloseIcon/index.tsx
+++ b/src/components/CloseIcon/index.tsx
@@ -1,5 +1,6 @@
 import { X } from 'react-feather'
 
+// @ts-ignore TYPE NEEDS FIXING
 const CloseIcon = (props) => <X className="cursor-pointer" {...props} />
 
 export default CloseIcon

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -150,8 +150,10 @@ export default function CurrencyInputPanel({
               )}
               <Input.Numeric
                 id="token-amount-input"
+                // @ts-ignore TYPE NEEDS FIXING
                 value={value}
                 onUserInput={(val) => {
+                  // @ts-ignore TYPE NEEDS FIXING
                   onUserInput(val)
                 }}
               />

--- a/src/components/CurrencyLogo/CurrencyLogo.tsx
+++ b/src/components/CurrencyLogo/CurrencyLogo.tsx
@@ -25,21 +25,25 @@ const BLOCKCHAIN = {
   [ChainId.HARDHAT]: 'hardhat',
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getCurrencyLogoUrls = (currency): string[] => {
   const urls: string[] = []
 
   if (currency.chainId in BLOCKCHAIN) {
     urls.push(
+      // @ts-ignore TYPE NEEDS FIXING
       `https://raw.githubusercontent.com/sushiswap/logos/main/network/${BLOCKCHAIN[currency.chainId]}/${
         currency.address
       }.jpg`
     )
     urls.push(
+      // @ts-ignore TYPE NEEDS FIXING
       `https://raw.githubusercontent.com/sushiswap/assets/master/blockchains/${BLOCKCHAIN[currency.chainId]}/assets/${
         currency.address
       }/logo.png`
     )
     urls.push(
+      // @ts-ignore TYPE NEEDS FIXING
       `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${BLOCKCHAIN[currency.chainId]}/assets/${
         currency.address
       }/logo.png`
@@ -111,6 +115,7 @@ const CurrencyLogo: FunctionComponent<CurrencyLogoProps> = ({ currency, size = '
 
   const srcs: string[] = useMemo(() => {
     if (currency?.isNative || currency?.equals(WNATIVE[currency.chainId])) {
+      // @ts-ignore TYPE NEEDS FIXING
       return [LOGO[currency.chainId], UNKNOWN_ICON]
     }
 

--- a/src/components/DebugObserver/index.tsx
+++ b/src/components/DebugObserver/index.tsx
@@ -10,5 +10,6 @@ export function DebugObserver(): JSX.Element {
     }
   }, [snapshot])
 
+  // @ts-ignore TYPE NEEDS FIXING
   return null
 }

--- a/src/components/ExternalLink/index.tsx
+++ b/src/components/ExternalLink/index.tsx
@@ -50,6 +50,7 @@ const ExternalLink: FC<ExternalLinkProps> = ({
       onClick={handleClick}
       className={classNames(
         'text-baseline whitespace-nowrap',
+        // @ts-ignore TYPE NEEDS FIXING
         COLOR[color],
         (startIcon || endIcon) && 'space-x-1 flex items-center justify-center',
         className

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -14,6 +14,7 @@ export const DEFAULT_FORM_FIELD_CLASSNAMES =
   'appearance-none outline-none rounded placeholder:text-low-emphesis bg-dark-1000/40 px-3 py-2 focus:ring-purple focus:border-purple block w-full min-w-0 border border-dark-800'
 
 export interface FormProps extends UseFormReturn<any> {
+  // @ts-ignore TYPE NEEDS FIXING
   onSubmit(x): void
   children: ReactElement<FormCardProps>
 }

--- a/src/components/Header/DesktopNav.tsx
+++ b/src/components/Header/DesktopNav.tsx
@@ -140,6 +140,7 @@ export const DesktopNav: FC<DesktopNavProps> = ({ mobileMenuOpen }) => {
             {account && chainId && userEthBalance && (
               <Link href="/balances" passHref={true}>
                 <a className="px-3 text-high-emphesis text-bold hidden md:block">
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {userEthBalance?.toSignificant(4)} {NATIVE[chainId].symbol}
                 </a>
               </Link>

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -4,6 +4,7 @@ import { FC } from 'react'
 
 import { shimmer } from './shimmer'
 
+// @ts-ignore TYPE NEEDS FIXING
 const toBase64 = (str) => (typeof window === 'undefined' ? Buffer.from(str).toString('base64') : window.btoa(str))
 
 const Image: FC<ImageProps> = ({ src, width, height, layout, ...rest }) => {

--- a/src/components/Image/shimmer.ts
+++ b/src/components/Image/shimmer.ts
@@ -1,3 +1,4 @@
+// @ts-ignore TYPE NEEDS FIXING
 export const shimmer = (w, h) => `
 <svg width="${w}" height="${h}" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>

--- a/src/components/LanguageSwitch/index.tsx
+++ b/src/components/LanguageSwitch/index.tsx
@@ -1,6 +1,7 @@
 import { ChevronDownIcon } from '@heroicons/react/solid'
 import Popover from 'app/components/Popover'
 import { classNames } from 'app/functions'
+// @ts-ignore TYPE NEEDS FIXING
 import cookieCutter from 'cookie-cutter'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -43,6 +44,7 @@ export default function LangSwitcher() {
         onClick={() => setShow(!show)}
         className="cursor-pointer bg-dark-1000 inline-flex justify-center w-full px-4 py-2 text-sm font-bold bg-transparent border-2 rounded shadow-sm text-primary border-dark-800 hover:border-dark-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-dark-700 focus:ring-dark-800"
       >
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {LANG_TO_COUNTRY[locale]}
         <ChevronDownIcon className="w-5 h-5 ml-2 -mr-1" aria-hidden="true" />
       </div>
@@ -55,6 +57,7 @@ export const LanguageSwitcherContent = ({ onClick }: { onClick?(): void }) => {
   return (
     <div className="px-2 mt-3">
       <div className="shadow-lg overflow-hidden bg-dark-900 rounded border border-dark-700">
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {locales.map((l) => {
           return (
             <div key={l} onClick={onClick}>
@@ -64,6 +67,7 @@ export const LanguageSwitcherContent = ({ onClick }: { onClick?(): void }) => {
                   onClick={() => cookieCutter.set('NEXT_LOCALE', l)}
                 >
                   <Typography variant="xs" weight={700}>
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     {LANG_TO_COUNTRY[l]}
                   </Typography>
                 </a>

--- a/src/components/LineGraph/index.tsx
+++ b/src/components/LineGraph/index.tsx
@@ -2,9 +2,11 @@ import { localPoint } from '@visx/event'
 import { LinearGradient } from '@visx/gradient'
 import { scaleLinear } from '@visx/scale'
 import { Bar, LinePath } from '@visx/shape'
+// @ts-ignore TYPE NEEDS FIXING
 import { bisector } from 'd3-array'
 import { FC, MouseEvent, TouchEvent, useRef } from 'react'
 import { useCallback, useMemo } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import AutoSizer from 'react-virtualized-auto-sizer'
 
 interface LineGraphProps {
@@ -31,6 +33,7 @@ interface GraphProps extends LineGraphProps {
   height: number
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const bisect = bisector((d) => d.x).center
 
 const Graph: FC<GraphProps> = ({ data, stroke, strokeWidth, width, height, setSelectedIndex }) => {
@@ -63,8 +66,11 @@ const Graph: FC<GraphProps> = ({ data, stroke, strokeWidth, width, height, setSe
       // Add check to avoid unnecessary changes and setState to DOM
       if (d && dRef.current !== index) {
         dRef.current = index
+        // @ts-ignore TYPE NEEDS FIXING
         circleRef.current.setAttribute('cx', xScale(d.x).toString())
+        // @ts-ignore TYPE NEEDS FIXING
         circleRef.current.setAttribute('cy', yScale(d.y).toString())
+        // @ts-ignore TYPE NEEDS FIXING
         setSelectedIndex(index)
       }
     },
@@ -72,22 +78,27 @@ const Graph: FC<GraphProps> = ({ data, stroke, strokeWidth, width, height, setSe
   )
 
   const showTooltip = useCallback(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     circleRef.current.setAttribute('display', 'block')
   }, [])
 
   const hideTooltip = useCallback(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     setSelectedIndex(data.length - 1)
+    // @ts-ignore TYPE NEEDS FIXING
     circleRef.current.setAttribute('display', 'none')
   }, [data, setSelectedIndex])
 
   return (
     <div className="w-full h-full">
       <svg width={width} height={height}>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {'gradient' in stroke && (
           <LinearGradient id="gradient" from={stroke.gradient.from} to={stroke.gradient.to} vertical={false} />
         )}
         {setSelectedIndex && (
           <g>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             <circle ref={circleRef} r={4} fill={'solid' in stroke ? stroke.solid : '#ffffff'} display="none" />
           </g>
         )}
@@ -95,6 +106,7 @@ const Graph: FC<GraphProps> = ({ data, stroke, strokeWidth, width, height, setSe
           data={data}
           x={(d) => xScale(d.x) ?? 0}
           y={(d) => yScale(d.y) ?? 0}
+          // @ts-ignore TYPE NEEDS FIXING
           stroke={'solid' in stroke ? stroke.solid : "url('#gradient')"}
           strokeWidth={strokeWidth}
         />
@@ -124,6 +136,7 @@ const LineGraph: FC<LineGraphProps> = ({
   if (data)
     return (
       <AutoSizer>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {({ width, height }) => <Graph {...{ data, stroke, strokeWidth, width, height, setSelectedIndex }} />}
       </AutoSizer>
     )

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -7,6 +7,7 @@ interface ItemProps {
 
 export function Item({ item, className }: ItemProps) {
   return (
+    // @ts-ignore TYPE NEEDS FIXING
     <li className={classNames('px-4 py-4 overflow-hidden bg-white shadow sm:px-6 sm:rounded-md', className)}>{item}</li>
   )
 }

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore TYPE NEEDS FIXING
 const Main = ({ children }) => (
   <main className="flex flex-col items-center justify-start flex-grow w-full h-full" style={{ height: 'max-content' }}>
     {children}

--- a/src/components/Modal/HeadlessUIModal.tsx
+++ b/src/components/Modal/HeadlessUIModal.tsx
@@ -68,6 +68,7 @@ const HeadlessUiModal: HeadlessUiModalType<Props> = ({ children: childrenProp, t
 
   // If children is a function, render props
   // Else just render normally
+  // @ts-ignore TYPE NEEDS FIXING
   const children = useMemo(
     () => (typeof childrenProp === 'function' ? childrenProp({ onClick, open, setOpen }) : children),
     [onClick, open, childrenProp]

--- a/src/components/NavLink/index.tsx
+++ b/src/components/NavLink/index.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import React, { Children } from 'react'
 
+// @ts-ignore TYPE NEEDS FIXING
 const NavLink = ({ children, exact = false, activeClassName = 'text-high-emphesis', ...props }) => {
   const { asPath, pathname, route, query, basePath } = useRouter()
   const child = Children.only(children)

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -20,6 +20,7 @@ const RIGHT_PAGE = 'RIGHT'
  * Helper method for creating a range of numbers
  * range(1, 5) => [1, 2, 3, 4, 5]
  */
+// @ts-ignore TYPE NEEDS FIXING
 const range = (from, to, step = 1): (string | number)[] => {
   let i = from
   const range: (string | number)[] = []

--- a/src/components/Paper/index.tsx
+++ b/src/components/Paper/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function Paper({ children, className, ...rest }): JSX.Element {
   return (
     <div className={`rounded ${className}`} {...rest}>

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -3,6 +3,7 @@ import { Placement } from '@popperjs/core'
 import { classNames } from 'app/functions'
 import useInterval from 'app/hooks/useInterval'
 import React, { Fragment, useCallback, useState } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import ReactDOM from 'react-dom'
 import { usePopper } from 'react-popper'
 

--- a/src/components/Popups/PopupItem.tsx
+++ b/src/components/Popups/PopupItem.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect } from 'react'
 
 import TransactionPopup from './TransactionPopup'
 
+// @ts-ignore TYPE NEEDS FIXING
 const AnimatedFader = ({ duration }) => (
   <div className="h-[3px] bg-dark-800 w-full">
     <style jsx>{`

--- a/src/components/Popups/index.tsx
+++ b/src/components/Popups/index.tsx
@@ -17,6 +17,7 @@ const Popups: FC = () => {
           urlWarningActive ? 'top-[108px]' : 'top-[88px]'
         }`}
       >
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {activePopups.map((item) => (
           <PopupItem key={item.key} content={item.content} popKey={item.key} removeAfterMs={item.removeAfterMs} />
         ))}
@@ -29,6 +30,7 @@ const Popups: FC = () => {
           {activePopups // reverse so new items up front
             .slice(0)
             .reverse()
+            // @ts-ignore TYPE NEEDS FIXING
             .map((item) => (
               <PopupItem key={item.key} content={item.content} popKey={item.key} removeAfterMs={item.removeAfterMs} />
             ))}

--- a/src/components/RenderAsync/index.tsx
+++ b/src/components/RenderAsync/index.tsx
@@ -6,6 +6,7 @@ interface RenderAsyncProps<ObjectType> {
   loader: ReactNode
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 function RenderAsync<ObjectType extends RenderAsyncProps<ObjectType>>({ children, promise, loader }) {
   const [data, setData] = useState()
 

--- a/src/components/ScrollableGraph/Curve.tsx
+++ b/src/components/ScrollableGraph/Curve.tsx
@@ -25,15 +25,19 @@ const axisLeftTickLabelProps = {
 }
 
 // accessors
+// @ts-ignore TYPE NEEDS FIXING
 const getX = (d) => new Date(d.date)
+// @ts-ignore TYPE NEEDS FIXING
 const getY = (d) => Number(d.value)
 
 export default function CurveChart({
+  // @ts-ignore TYPE NEEDS FIXING
   data,
   gradientColor = undefined,
   index = undefined,
   even = undefined,
   height = undefined,
+  // @ts-ignore TYPE NEEDS FIXING
   width,
   yMax = undefined,
   margin = { top: 0, right: 0, bottom: 0, left: 0 },
@@ -57,7 +61,9 @@ export default function CurveChart({
       <LinePath
         curve={curveNatural}
         data={data}
+        // @ts-ignore TYPE NEEDS FIXING
         x={(d) => xScale(getX(d)) ?? 0}
+        // @ts-ignore TYPE NEEDS FIXING
         y={(d) => yScale(getY(d)) ?? 0}
         stroke={stroke}
         strokeWidth={strokeWidth}
@@ -70,6 +76,7 @@ export default function CurveChart({
       {!hideBottomAxis && (
         <AxisBottom
           top={yMax}
+          // @ts-ignore TYPE NEEDS FIXING
           scale={xScale}
           numTicks={width > 520 ? 10 : 5}
           stroke={axisColor}
@@ -79,6 +86,7 @@ export default function CurveChart({
       )}
       {!hideLeftAxis && (
         <AxisLeft
+          // @ts-ignore TYPE NEEDS FIXING
           scale={yScale}
           numTicks={5}
           tickFormat={millify as any}

--- a/src/components/ScrollableGraph/Curves.tsx
+++ b/src/components/ScrollableGraph/Curves.tsx
@@ -6,7 +6,9 @@ import { LegendOrdinal } from '@visx/legend'
 import { MarkerArrow, MarkerCross, MarkerLine, MarkerX } from '@visx/marker'
 import { PatternLines } from '@visx/pattern'
 import { scaleLinear, scaleOrdinal, scaleTime } from '@visx/scale'
+// @ts-ignore TYPE NEEDS FIXING
 import { extent } from 'd3-array'
+// @ts-ignore TYPE NEEDS FIXING
 import { timeFormat, timeParse } from 'd3-time-format'
 import millify from 'millify'
 import { useMemo, useState } from 'react'
@@ -14,7 +16,9 @@ import React from 'react'
 
 import Curve from './Curve'
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getX = (data) => new Date(data.date)
+// @ts-ignore TYPE NEEDS FIXING
 export const getY = (data) => data.value
 
 const brushMargin = { top: 10, bottom: 15, left: 50, right: 20 }
@@ -32,6 +36,7 @@ const parseDate = timeParse('%Y-%m-%d')
 
 const format = timeFormat('%b %d')
 
+// @ts-ignore TYPE NEEDS FIXING
 const formatDate = (date) => format(parseDate(date))
 
 const axisColor = 'currentColor'
@@ -57,25 +62,33 @@ const purple3 = '#a44afe'
 
 const Curves = ({
   compact = false,
+  // @ts-ignore TYPE NEEDS FIXING
   width,
+  // @ts-ignore TYPE NEEDS FIXING
   height,
   margin = { top: 64, right: 32, bottom: 16, left: 64 },
+  // @ts-ignore TYPE NEEDS FIXING
   data,
   title = undefined,
   labels = undefined,
   note = undefined,
   colors = [purple1, purple2, purple3],
 }) => {
+  // @ts-ignore TYPE NEEDS FIXING
   const allData = data.reduce((previousValue, currentValue) => previousValue.concat(currentValue), [])
 
   const [filteredData, setFilteredData] = useState(
+    // @ts-ignore TYPE NEEDS FIXING
     data.map((curve) => curve.slice(curve.length - 30, curve.length - 1))
   )
 
+  // @ts-ignore TYPE NEEDS FIXING
   const onBrushChange = (domain) => {
     if (!domain) return
     const { x0, x1, y0, y1 } = domain
+    // @ts-ignore TYPE NEEDS FIXING
     const stockCopy = data.map((d) =>
+      // @ts-ignore TYPE NEEDS FIXING
       d.filter((s) => {
         const x = getX(s).getTime()
         const y = getY(s)
@@ -103,6 +116,7 @@ const Curves = ({
       scaleTime({
         range: [0, xMax],
         domain: extent(
+          // @ts-ignore TYPE NEEDS FIXING
           filteredData.reduce((previousValue, currentValue) => previousValue.concat(currentValue), []),
           getX
         ),
@@ -117,12 +131,16 @@ const Curves = ({
         domain: [
           Math.min(
             ...filteredData
+              // @ts-ignore TYPE NEEDS FIXING
               .reduce((previousValue, currentValue) => previousValue.concat(currentValue), [])
+              // @ts-ignore TYPE NEEDS FIXING
               .map((d) => getY(d))
           ),
           Math.max(
             ...filteredData
+              // @ts-ignore TYPE NEEDS FIXING
               .reduce((previousValue, currentValue) => previousValue.concat(currentValue), [])
+              // @ts-ignore TYPE NEEDS FIXING
               .map((d) => getY(d))
           ),
         ],
@@ -146,6 +164,7 @@ const Curves = ({
     () =>
       scaleLinear({
         range: [yBrushMax, 0],
+        // @ts-ignore TYPE NEEDS FIXING
         domain: [Math.min(...allData.map((d) => getY(d))), Math.max(...allData.map((d) => getY(d)))],
         nice: true,
       }),
@@ -191,6 +210,7 @@ const Curves = ({
             top: margin.top / 2 - 10,
           }}
         >
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           <LegendOrdinal scale={scaleOrdinal({ domain: [title] })} direction="row" labelMargin="0 15px 0 0" />
         </div>
       )}
@@ -203,6 +223,7 @@ const Curves = ({
             right: margin.right,
           }}
         >
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           <LegendOrdinal scale={scaleOrdinal({ domain: [note] })} direction="row" labelMargin="0 4px 0 0" />
         </div>
       )}
@@ -232,6 +253,7 @@ const Curves = ({
         />
         <Group top={margin.top} left={margin.left}>
           {width > 8 &&
+            // @ts-ignore TYPE NEEDS FIXING
             filteredData.map((curve, i) => {
               const even = i % 2 === 0
               let markerStart = even ? 'url(#marker-cross)' : 'url(#marker-x)'
@@ -267,13 +289,21 @@ const Curves = ({
                     hideLeftAxis
                     data={curve}
                     width={width}
+                    // @ts-ignore TYPE NEEDS FIXING
                     xScale={xScale}
+                    // @ts-ignore TYPE NEEDS FIXING
                     yScale={yScale}
+                    //@ts-ignore TYPE NEEDS FIXING
                     stroke={colors[i]}
+                    // @ts-ignore TYPE NEEDS FIXING
                     strokeWidth={2}
+                    // @ts-ignore TYPE NEEDS FIXING
                     strokeOpacity={1}
+                    // @ts-ignore TYPE NEEDS FIXING
                     markerMid="url(#marker-circle)"
+                    // @ts-ignore TYPE NEEDS FIXING
                     markerStart={markerStart}
+                    // @ts-ignore TYPE NEEDS FIXING
                     markerEnd={markerEnd}
                   />
                 </Group>
@@ -298,6 +328,7 @@ const Curves = ({
         </Group>
 
         <Group top={topChartHeight + topChartBottomMargin + margin.top} left={brushMargin.left}>
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           {data.map((brushData, i) => {
             const even = i % 2 === 0
             let markerStart = even ? 'url(#marker-cross)' : 'url(#marker-x)'
@@ -305,15 +336,21 @@ const Curves = ({
             const markerEnd = even ? 'url(#marker-arrow)' : 'url(#marker-arrow-odd)'
             return (
               <Curve
+                // @ts-ignore TYPE NEEDS FIXING
                 stroke={colors[i]}
+                // @ts-ignore TYPE NEEDS FIXING
                 strokeWidth={2}
+                // @ts-ignore TYPE NEEDS FIXING
                 strokeOpacity={1}
                 hideBottomAxis
                 hideLeftAxis
                 data={brushData}
                 width={width}
+                // @ts-ignore TYPE NEEDS FIXING
                 yMax={yBrushMax}
+                // @ts-ignore TYPE NEEDS FIXING
                 xScale={brushXScale}
+                // @ts-ignore TYPE NEEDS FIXING
                 yScale={brushYScale}
                 key={i}
               />

--- a/src/components/ScrollableGraph/index.tsx
+++ b/src/components/ScrollableGraph/index.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore TYPE NEEDS FIXING
 import AutoSizer from 'react-virtualized-auto-sizer'
 
 import Curves from './Curves'
@@ -21,6 +22,7 @@ export default function ScrollableGraph(props: ScrollableGraphProps) {
   return (
     <>
       {props.data && props.data[0]?.length !== 0 && (
+        // @ts-ignore TYPE NEEDS FIXING
         <AutoSizer>{({ width, height }) => <Curves {...props} width={width} height={height} />}</AutoSizer>
       )}
     </>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -5,6 +5,7 @@ import { useOnClickOutside } from '../../hooks/useOnClickOutside'
 import useToggle from '../../hooks/useToggle'
 
 interface NeonSelectProps {
+  // @ts-ignore TYPE NEEDS FIXING
   value
   children: React.ReactElement<NeonSelectItemProps> | React.ReactElement<NeonSelectItemProps>[]
 }
@@ -15,6 +16,7 @@ const NeonSelect: FC<NeonSelectProps> = ({ value, children }) => {
   useOnClickOutside(node, open ? toggle : undefined)
 
   return (
+    // @ts-ignore TYPE NEEDS FIXING
     <div className="relative" ref={node} onClick={toggle}>
       <div className="shadow-md z-[2] relative flex border border-dark-800 bg-dark-900 h-[38px] rounded-md divide-x divide-dark-800">
         <div className="text-sm text-primary flex items-center pl-3 min-w-[80px] font-medium">{value}</div>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -98,6 +98,7 @@ const SettingsTab: FC<SettingsTabProps> = ({ placeholderSlippage, trident = fals
                   />
                 </div>
               )}
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {OPENMEV_ENABLED && OPENMEV_SUPPORTED_NETWORKS.includes(chainId) && (
                 <div className="flex items-center justify-between">
                   <div className="flex items-center">

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -12,7 +12,9 @@ type SwitchProps = ComponentProps<typeof HeadlessUiSwitch> & {
 }
 
 const COLOR = {
+  // @ts-ignore TYPE NEEDS FIXING
   default: (checked) => (checked ? 'bg-high-emphesis' : 'bg-high-emphesis'),
+  // @ts-ignore TYPE NEEDS FIXING
   gradient: (checked) => (checked ? 'bg-gradient-to-r from-blue to-pink' : 'bg-dark-700'),
 }
 

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/outline'
 import { useRouter } from 'next/router'
 import React, { ReactNode, useState } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import { usePagination, useSortBy, useTable } from 'react-table'
 
 import { classNames } from '../../functions'
@@ -11,6 +12,7 @@ export interface Column {
   accessor: string | ((row: any) => ReactNode)
   align?: string
   disableSortBy?: boolean
+  // @ts-ignore TYPE NEEDS FIXING
   sortType?: (a, b) => number
 }
 
@@ -73,13 +75,17 @@ export default function Table<T>({
     usePagination
   )
 
+  // @ts-ignore TYPE NEEDS FIXING
   const toggleHide = (e) => {
+    // @ts-ignore TYPE NEEDS FIXING
     const list = allColumns.filter((column) => columnsHideable.find((c) => c === column.id))
+    // @ts-ignore TYPE NEEDS FIXING
     list.forEach((column) => column.toggleHidden(!isHidden))
     setHidden(!isHidden)
     e.stopPropagation()
   }
 
+  // @ts-ignore TYPE NEEDS FIXING
   const getProperty = (obj, prop) => {
     var parts = prop.split('.')
 
@@ -111,8 +117,10 @@ export default function Table<T>({
       <div className="w-full overflow-x-auto">
         <table className="w-auto min-w-full border-collapse table-fixed" {...getTableProps()}>
           <thead>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {headerGroups.map((headerGroup) => (
               <tr key="tr" {...headerGroup.getHeaderGroupProps()}>
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {headerGroup.headers.map((column, i, columns) => (
                   <th key={i} {...column.getHeaderProps(column.getSortByToggleProps())}>
                     <div
@@ -171,10 +179,12 @@ export default function Table<T>({
             ))}
           </thead>
           <tbody {...getTableBodyProps()}>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {page.map((row, i) => {
               prepareRow(row)
               return (
                 <tr key={i} {...row.getRowProps()}>
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {row.cells.map((cell, cI) => {
                     return (
                       <td key={cI} className="pb-3 pl-0 pr-0" {...cell.getCellProps()}>

--- a/src/components/TimespanGraph/Curves.tsx
+++ b/src/components/TimespanGraph/Curves.tsx
@@ -6,6 +6,7 @@ import { Group } from '@visx/group'
 import { PatternLines } from '@visx/pattern'
 import { scaleLinear, scaleTime } from '@visx/scale'
 import { LinePath } from '@visx/shape'
+// @ts-ignore TYPE NEEDS FIXING
 import { extent } from 'd3-array'
 import millify from 'millify'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -14,7 +15,9 @@ import React from 'react'
 import { classNames } from '../../functions'
 import { TimespanGraphProps } from '.'
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getX = (data) => new Date(data.date)
+// @ts-ignore TYPE NEEDS FIXING
 export const getY = (data) => data.value
 
 interface Dimensions {
@@ -68,16 +71,21 @@ const Curves = ({
   const [timespan, setTimespan] = useState(timespans?.find((t) => t.text === defaultTimespan))
   const brushRef = useRef<BaseBrush | null>(null)
 
+  // @ts-ignore TYPE NEEDS FIXING
   const allData = data.reduce((previousValue, currentValue) => previousValue.concat(currentValue), [])
 
   const [filteredData, setFilteredData] = useState(
+    // @ts-ignore TYPE NEEDS FIXING
     data.map((curve) => curve.slice(curve.length - 30, curve.length - 1))
   )
 
+  // @ts-ignore TYPE NEEDS FIXING
   const onBrushChange = (domain) => {
     if (!domain) return
     const { x0, x1, y0, y1 } = domain
+    // @ts-ignore TYPE NEEDS FIXING
     const stockCopy = data.map((d) =>
+      // @ts-ignore TYPE NEEDS FIXING
       d.filter((s) => {
         const x = getX(s).getTime()
         const y = getY(s)
@@ -105,6 +113,7 @@ const Curves = ({
       scaleTime({
         range: [0, xMax],
         domain: extent(
+          // @ts-ignore TYPE NEEDS FIXING
           filteredData.reduce((previousValue, currentValue) => previousValue.concat(currentValue), []),
           getX
         ),
@@ -120,12 +129,16 @@ const Curves = ({
         domain: [
           Math.min(
             ...filteredData
+              // @ts-ignore TYPE NEEDS FIXING
               .reduce((previousValue, currentValue) => previousValue.concat(currentValue), [])
+              // @ts-ignore TYPE NEEDS FIXING
               .map((d) => getY(d))
           ),
           Math.max(
             ...filteredData
+              // @ts-ignore TYPE NEEDS FIXING
               .reduce((previousValue, currentValue) => previousValue.concat(currentValue), [])
+              // @ts-ignore TYPE NEEDS FIXING
               .map((d) => getY(d))
           ),
         ],
@@ -149,6 +162,7 @@ const Curves = ({
     () =>
       scaleLinear({
         range: [yBrushMax, 0],
+        // @ts-ignore TYPE NEEDS FIXING
         domain: [Math.min(...allData.map((d) => getY(d))), Math.max(...allData.map((d) => getY(d)))],
         nice: true,
       }),
@@ -168,6 +182,7 @@ const Curves = ({
     if (brushRef?.current) {
       const updater: UpdateBrush = (prevBrush) => {
         const lastDate = data[0][data[0].length - 1].date
+        // @ts-ignore TYPE NEEDS FIXING
         const firstDate = data[0].find((data) => data.date >= lastDate - t.length * 1000)
 
         const newExtent = brushRef.current!.getExtent(
@@ -260,6 +275,7 @@ const Curves = ({
         />
         <Group top={margin.top} left={margin.left}>
           {width > 8 &&
+            // @ts-ignore TYPE NEEDS FIXING
             filteredData.map((curve, i) => (
               <LinePath
                 key={`chart-${i}-${timespan?.text}`}
@@ -289,6 +305,7 @@ const Curves = ({
         </Group>
 
         <Group top={topChartHeight + topChartBottomMargin + margin.top} left={brushMargin.left}>
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           {data.map((brushData, i) => {
             return (
               <LinePath

--- a/src/components/TimespanGraph/index.tsx
+++ b/src/components/TimespanGraph/index.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore TYPE NEEDS FIXING
 import AutoSizer from 'react-virtualized-auto-sizer'
 
 import Curves from './Curves'
@@ -20,6 +21,7 @@ export default function TimespanGraph(props: TimespanGraphProps) {
   return (
     <>
       {props.data && props.data[0]?.length !== 0 && (
+        // @ts-ignore TYPE NEEDS FIXING
         <AutoSizer>{({ width, height }) => <Curves {...props} width={width} height={height} />}</AutoSizer>
       )}
     </>

--- a/src/components/ToggleButton/index.tsx
+++ b/src/components/ToggleButton/index.tsx
@@ -7,6 +7,7 @@ import Typography from '../Typography'
 const FILLED = {
   group: 'border border-dark-800 rounded p-0.5 bg-dark-900',
   option: {
+    // @ts-ignore TYPE NEEDS FIXING
     checked: (checked) => (checked ? 'border-transparent border-gradient-r-blue-pink-dark-900' : 'border-transparent'),
     default: 'py-1 rounded-lg border',
   },
@@ -15,6 +16,7 @@ const FILLED = {
 const OUTLINED = {
   group: 'gap-2',
   option: {
+    // @ts-ignore TYPE NEEDS FIXING
     checked: (checked) => (checked ? 'border-dark-700 bg-gradient-to-r from-blue to-pink' : 'border-dark-700'),
     default: 'py-3 rounded border',
   },
@@ -67,7 +69,9 @@ ToggleButtonGroup.Button = ({
           className={classNames(
             checked ? classNames(activeClassName, className) : className,
             'h-full flex items-center justify-center cursor-pointer focus:none',
+            // @ts-ignore TYPE NEEDS FIXING
             VARIANTS[variant].option.checked(checked),
+            // @ts-ignore TYPE NEEDS FIXING
             VARIANTS[variant].option.default
           )}
         >

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -49,6 +49,7 @@ const Typography: FC<TypographyProps> = forwardRef(
       {
         className: classNames(
           VARIANTS[variant],
+          // @ts-ignore TYPE NEEDS FIXING
           WEIGHTS[weight],
           onClick ? 'cursor-pointer select-none' : '',
           className

--- a/src/components/Web3Network/index.tsx
+++ b/src/components/Web3Network/index.tsx
@@ -18,6 +18,7 @@ function Web3Network(): JSX.Element | null {
       onClick={() => toggleNetworkModal()}
     >
       <div className="grid items-center grid-flow-col items-center justify-center bg-dark-1000 h-[36px] w-[36px] text-sm rounded pointer-events-auto auto-cols-max text-secondary">
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <Image src={NETWORK_ICON[chainId]} alt="Switch Network" className="rounded-md" width="22px" height="22px" />
       </div>
       <NetworkModel />

--- a/src/components/Web3ProviderNetwork/index.tsx
+++ b/src/components/Web3ProviderNetwork/index.tsx
@@ -3,6 +3,7 @@ import { NetworkContextName } from 'app/constants'
 
 const Web3ReactRoot = createWeb3ReactRoot(NetworkContextName)
 
+// @ts-ignore TYPE NEEDS FIXING
 function Web3ProviderNetwork({ children, getLibrary }) {
   return <Web3ReactRoot getLibrary={getLibrary}>{children}</Web3ReactRoot>
 }

--- a/src/components/Web3ReactManager/GnosisManager.tsx
+++ b/src/components/Web3ReactManager/GnosisManager.tsx
@@ -4,5 +4,6 @@ const safeMultisigConnector = new SafeAppConnector()
 
 export default function GnosisManager(): JSX.Element {
   const triedToConnectToSafe = useSafeAppConnection(safeMultisigConnector)
+  // @ts-ignore TYPE NEEDS FIXING
   return null
 }

--- a/src/config/routing.ts
+++ b/src/config/routing.ts
@@ -77,17 +77,29 @@ const WRAPPED_NATIVE_ONLY: ChainTokenList = {
 export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
   ...WRAPPED_NATIVE_ONLY,
   [ChainId.ETHEREUM]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.ETHEREUM],
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.DAI,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.RUNE,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.NFTX,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.STETH,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.OHM_V1,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.OHM_V2,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.ETHEREUM],
   ],
   [ChainId.MATIC]: [
@@ -127,14 +139,23 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
   ],
   [ChainId.XDAI]: [...WRAPPED_NATIVE_ONLY[ChainId.XDAI], XDAI.USDC, XDAI.USDT, XDAI.WBTC, XDAI.WETH],
   [ChainId.AVALANCHE]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.AVALANCHE],
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.DAI,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.TIME,
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.AVALANCHE],
   ],
   [ChainId.HARMONY]: [
@@ -236,147 +257,262 @@ export const CUSTOM_BASES: {
  */
 export const COMMON_BASES: ChainTokenList = {
   [ChainId.ETHEREUM]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.ETHEREUM],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.ETHEREUM],
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.SPELL,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.ICE,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.DAI,
+    // @ts-ignore TYPE NEEDS FIXING
     ETHEREUM.OHM_V2,
   ],
   [ChainId.MATIC]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.MATIC],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.MATIC],
+    // @ts-ignore TYPE NEEDS FIXING
     MATIC.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     MATIC.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     MATIC.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     MATIC.ICE,
+    // @ts-ignore TYPE NEEDS FIXING
     MATIC.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     MATIC.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     MATIC.DAI,
   ],
   [ChainId.FANTOM]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.FANTOM],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.FANTOM],
+    // @ts-ignore TYPE NEEDS FIXING
     FANTOM.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     FANTOM.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     FANTOM.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     FANTOM.ICE,
+    // @ts-ignore TYPE NEEDS FIXING
     FANTOM.SPELL,
+    // @ts-ignore TYPE NEEDS FIXING
     FANTOM.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     FANTOM.DAI,
   ],
   [ChainId.BSC]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.BSC],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.BSC],
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.BTCB,
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.SPELL,
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.ICE,
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.DAI,
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     BSC.USD,
   ],
   [ChainId.ARBITRUM]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.ARBITRUM],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.ARBITRUM],
+    // @ts-ignore TYPE NEEDS FIXING
     ARBITRUM.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     ARBITRUM.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     ARBITRUM.SPELL,
+    // @ts-ignore TYPE NEEDS FIXING
     ARBITRUM.ICE,
+    // @ts-ignore TYPE NEEDS FIXING
     ARBITRUM.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     ARBITRUM.USDT,
   ],
   [ChainId.XDAI]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.XDAI],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.XDAI],
+    // @ts-ignore TYPE NEEDS FIXING
     XDAI.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     XDAI.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     XDAI.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     XDAI.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     XDAI.GNO,
   ],
   [ChainId.AVALANCHE]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.AVALANCHE],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.AVALANCHE],
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.ICE,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.SPELL,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.WMEMO,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.DAI,
   ],
   [ChainId.HARMONY]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.HARMONY],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.HARMONY],
+    // @ts-ignore TYPE NEEDS FIXING
     HARMONY.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     HARMONY.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     HARMONY.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     HARMONY.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     HARMONY.DAI,
   ],
   [ChainId.HECO]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.HECO],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.HECO],
+    // @ts-ignore TYPE NEEDS FIXING
     HECO.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     HECO.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     HECO.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     HECO.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     HECO.DAI,
   ],
   [ChainId.OKEX]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.OKEX],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.OKEX],
+    // @ts-ignore TYPE NEEDS FIXING
     OKEX.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     OKEX.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     OKEX.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     OKEX.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     OKEX.DAI,
   ],
   [ChainId.CELO]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.CELO],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.CELO],
+    // @ts-ignore TYPE NEEDS FIXING
     CELO.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     CELO.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     CELO.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     CELO.cUSD,
+    // @ts-ignore TYPE NEEDS FIXING
     CELO.cEURO,
   ],
   [ChainId.MOONRIVER]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.MOONRIVER],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.MOONRIVER],
+    // @ts-ignore TYPE NEEDS FIXING
     MOONRIVER.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     MOONRIVER.BTC,
+    // @ts-ignore TYPE NEEDS FIXING
     MOONRIVER.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     MOONRIVER.FRAX,
+    // @ts-ignore TYPE NEEDS FIXING
     MOONRIVER.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     MOONRIVER.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     MOONRIVER.ROME,
   ],
   [ChainId.PALM]: [...WRAPPED_NATIVE_ONLY[ChainId.PALM], PALM.WETH, PALM.DAI],
   [ChainId.FUSE]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.FUSE],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.FUSE],
+    // @ts-ignore TYPE NEEDS FIXING
     FUSE.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     FUSE.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     FUSE.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     FUSE.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     FUSE.DAI,
   ],
   [ChainId.TELOS]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.TELOS],
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.TELOS],
+    // @ts-ignore TYPE NEEDS FIXING
     TELOS.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     TELOS.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     TELOS.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     TELOS.USDT,
   ],
 }
@@ -430,14 +566,23 @@ export const BASES_TO_TRACK_LIQUIDITY_FOR: ChainTokenList = {
   ],
   [ChainId.XDAI]: [...WRAPPED_NATIVE_ONLY[ChainId.XDAI], XDAI.USDC, XDAI.USDT, XDAI.WBTC, XDAI.WETH],
   [ChainId.AVALANCHE]: [
+    // @ts-ignore TYPE NEEDS FIXING
     ...WRAPPED_NATIVE_ONLY[ChainId.AVALANCHE],
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.DAI,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.USDT,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.WBTC,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.WETH,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.USDC,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.MIM,
+    // @ts-ignore TYPE NEEDS FIXING
     AVALANCHE.TIME,
+    // @ts-ignore TYPE NEEDS FIXING
     SUSHI[ChainId.AVALANCHE],
   ],
   [ChainId.HARMONY]: [
@@ -479,6 +624,7 @@ export const PINNED_PAIRS: {
   readonly [chainId in ChainId]?: [Token, Token][]
 } = {
   [ChainId.ETHEREUM]: [
+    // @ts-ignore TYPE NEEDS FIXING
     [SUSHI[ChainId.ETHEREUM], WNATIVE[ChainId.ETHEREUM]],
     [
       new Token(ChainId.ETHEREUM, '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643', 8, 'cDAI', 'Compound Dai'),

--- a/src/entities/KashiCooker.ts
+++ b/src/entities/KashiCooker.ts
@@ -47,6 +47,7 @@ export async function signMasterContractApproval(
     },
     message: message,
   }
+  // @ts-ignore TYPE NEEDS FIXING
   const signer = getSigner(library, user)
   return signer._signTypedData(typedData.domain, typedData.types, typedData.message)
 }

--- a/src/entities/connectors/FortmaticConnector.ts
+++ b/src/entities/connectors/FortmaticConnector.ts
@@ -17,6 +17,7 @@ const CHAIN_ID_NETWORK_ARGUMENT: {
 export class FortmaticConnector extends FortmaticConnectorCore {
   async activate() {
     if (!this.fortmatic) {
+      // @ts-ignore TYPE NEEDS FIXING
       const { default: Fortmatic } = await import('fortmatic')
 
       const { apiKey, chainId } = this as any

--- a/src/entities/connectors/NetworkConnector.ts
+++ b/src/entities/connectors/NetworkConnector.ts
@@ -92,6 +92,7 @@ class MiniRpcProvider implements AsyncSendable {
         reject,
         request: { method },
       } = byKey[result.id]
+      // @ts-ignore TYPE NEEDS FIXING
       if (resolve && reject) {
         if ('error' in result) {
           reject(new RequestError(result?.error?.message, result?.error?.code, result?.error?.data))
@@ -104,6 +105,7 @@ class MiniRpcProvider implements AsyncSendable {
     }
   }
 
+  // @ts-ignore TYPE NEEDS FIXING
   public readonly sendAsync = (
     request: {
       jsonrpc: '2.0'

--- a/src/entities/oracles/Oracle.ts
+++ b/src/entities/oracles/Oracle.ts
@@ -7,6 +7,7 @@ export abstract class Oracle {
   name = ''
   warning = ''
   error = ''
+  // @ts-ignore TYPE NEEDS FIXING
   constructor(chainId, address, name, data) {
     this.chainId = chainId
     this.address = address

--- a/src/features/analytics/AnalyticsContainer.tsx
+++ b/src/features/analytics/AnalyticsContainer.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import Container from '../../components/Container'
 import Sidebar from '../../components/Sidebar'
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function AnalyticsContainer({ children }): JSX.Element {
   return (
     <>

--- a/src/features/analytics/ChartCard.tsx
+++ b/src/features/analytics/ChartCard.tsx
@@ -35,9 +35,12 @@ export default function ChartCard({
     const currentDate = Math.round(Date.now() / 1000)
     return chart?.reduce((acc, cur) => {
       const x = cur.x.getTime()
+      // @ts-ignore TYPE NEEDS FIXING
       if (Math.round(x / 1000) >= currentDate - timespan?.length) {
         acc.push({
+          // @ts-ignore TYPE NEEDS FIXING
           x,
+          // @ts-ignore TYPE NEEDS FIXING
           y: cur.y,
         })
       }
@@ -47,7 +50,9 @@ export default function ChartCard({
   }, [chart, timespan?.length])
 
   const [selectedIndex, setSelectedIndex] = useState(chartFiltered?.length - 1)
+  // @ts-ignore TYPE NEEDS FIXING
   const overrideFigure = useMemo(() => chartFiltered?.[selectedIndex]?.y, [chartFiltered, selectedIndex])
+  // @ts-ignore TYPE NEEDS FIXING
   const overrideDate = useMemo(() => chartFiltered?.[selectedIndex]?.x, [chartFiltered, selectedIndex])
 
   return (

--- a/src/features/analytics/Dashboard/DashboardTabs.tsx
+++ b/src/features/analytics/Dashboard/DashboardTabs.tsx
@@ -15,6 +15,7 @@ const tabs = [
   },
 ]
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function DashboardTabs({ currentType, setType }): JSX.Element {
   return (
     <>

--- a/src/features/analytics/Farms/FarmList.tsx
+++ b/src/features/analytics/Farms/FarmList.tsx
@@ -45,7 +45,9 @@ function FarmListName({ pair }: FarmListNameProps): JSX.Element {
         <DoubleCurrencyLogo
           className="-space-x-3"
           logoClassName="rounded-full"
+          // @ts-ignore TYPE NEEDS FIXING
           currency0={token0}
+          // @ts-ignore TYPE NEEDS FIXING
           currency1={token1}
           size={40}
         />
@@ -107,6 +109,7 @@ export default function FarmList({ pools }: FarmListProps): JSX.Element {
       {
         Header: 'Pool Name',
         accessor: 'pair',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => <FarmListName pair={props.value} />,
         disableSortBy: true,
         align: 'left',
@@ -114,6 +117,7 @@ export default function FarmList({ pools }: FarmListProps): JSX.Element {
       {
         Header: 'Annual / Monthly / Daily APR',
         accessor: 'apr',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => (
           <div className="inline-flex flex-row font-medium">
             {props.value.annual < 10000 ? (
@@ -126,11 +130,13 @@ export default function FarmList({ pools }: FarmListProps): JSX.Element {
           </div>
         ),
         align: 'right',
+        // @ts-ignore TYPE NEEDS FIXING
         sortType: (a, b) => a.original.apr.annual - b.original.apr.annual,
       },
       {
         Header: 'TVL',
         accessor: 'liquidity',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => (
           <div className="text-base font-medium text-primary">{formatNumber(props.value, true, false)}</div>
         ),
@@ -139,6 +145,7 @@ export default function FarmList({ pools }: FarmListProps): JSX.Element {
       {
         Header: 'Daily Rewards',
         accessor: 'rewards',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => <Rewards rewards={props.value} />,
         disableSortBy: true,
         align: 'right',

--- a/src/features/analytics/Pairs/PairList.tsx
+++ b/src/features/analytics/Pairs/PairList.tsx
@@ -49,7 +49,9 @@ function PairListName({ pair }: PairListNameProps): JSX.Element {
         <DoubleCurrencyLogo
           className="-space-x-3"
           logoClassName="rounded-full"
+          // @ts-ignore TYPE NEEDS FIXING
           currency0={token0}
+          // @ts-ignore TYPE NEEDS FIXING
           currency1={token1}
           size={40}
         />
@@ -63,6 +65,7 @@ function PairListName({ pair }: PairListNameProps): JSX.Element {
   )
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const getApy = (volume, liquidity) => {
   const apy = aprToApy((((volume / 7) * 365 * 0.0025) / liquidity) * 100, 3650)
   if (apy > 1000) return '>10,000%'
@@ -73,23 +76,28 @@ const allColumns = [
   {
     Header: 'Pair',
     accessor: 'pair',
+    // @ts-ignore TYPE NEEDS FIXING
     Cell: (props) => <PairListName pair={props.value} />,
     align: 'left',
   },
   {
     Header: 'TVL',
     accessor: 'liquidity',
+    // @ts-ignore TYPE NEEDS FIXING
     Cell: (props) => formatNumberScale(props.value, true),
     align: 'right',
   },
   {
     Header: 'Annual APY',
+    // @ts-ignore TYPE NEEDS FIXING
     accessor: (row) => <div className="text-high-emphesis">{getApy(row.volume1w, row.liquidity)}</div>,
     align: 'right',
+    // @ts-ignore TYPE NEEDS FIXING
     sortType: (a, b) => a.original.volume1w / a.original.liquidity - b.original.volume1w / b.original.liquidity,
   },
   {
     Header: 'Daily / Weekly Volume',
+    // @ts-ignore TYPE NEEDS FIXING
     accessor: (row) => (
       <div>
         <div className="font-medium text-high-emphesis">{formatNumber(row.volume1d, true, false, 2)}</div>
@@ -100,6 +108,7 @@ const allColumns = [
   },
   {
     Header: 'Daily / Weekly Fees',
+    // @ts-ignore TYPE NEEDS FIXING
     accessor: (row) => (
       <div>
         <div className="font-medium text-high-emphesis">{formatNumber(row.volume1d * 0.003, true, false, 2)}</div>
@@ -114,6 +123,7 @@ const gainersColumns = [
   {
     Header: 'Pair',
     accessor: 'pair',
+    // @ts-ignore TYPE NEEDS FIXING
     Cell: (props) => <PairListName pair={props.value} />,
     disableSortBy: true,
     align: 'left',
@@ -121,6 +131,7 @@ const gainersColumns = [
   {
     Header: 'Daily / Weekly Liquidity Change',
     id: 'liquidity',
+    // @ts-ignore TYPE NEEDS FIXING
     accessor: (row) => (
       <div className="inline-flex flex-col">
         <div className="font-medium text-high-emphesis">
@@ -130,10 +141,12 @@ const gainersColumns = [
       </div>
     ),
     align: 'right',
+    // @ts-ignore TYPE NEEDS FIXING
     sortType: (a, b) => a.original.liquidityChangeNumber1d - b.original.liquidityChangeNumber1d,
   },
   {
     Header: '%',
+    // @ts-ignore TYPE NEEDS FIXING
     accessor: (row) => (
       <div className="inline-flex">
         <div>
@@ -143,10 +156,12 @@ const gainersColumns = [
       </div>
     ),
     align: 'right',
+    // @ts-ignore TYPE NEEDS FIXING
     sortType: (a, b) => a.original.liquidityChangePercent1d - b.original.liquidityChangePercent1d,
   },
   {
     Header: 'Daily / Weekly Volume Change',
+    // @ts-ignore TYPE NEEDS FIXING
     accessor: (row) => (
       <div className="inline-flex flex-col">
         <div className="font-medium text-high-emphesis">
@@ -156,10 +171,12 @@ const gainersColumns = [
       </div>
     ),
     align: 'right',
+    // @ts-ignore TYPE NEEDS FIXING
     sortType: (a, b) => a.original.volumeChangeNumber1d - b.original.volumeChangeNumber1d,
   },
   {
     Header: ' %',
+    // @ts-ignore TYPE NEEDS FIXING
     accessor: (row) => (
       <div className="inline-flex">
         <div>
@@ -169,6 +186,7 @@ const gainersColumns = [
       </div>
     ),
     align: 'right',
+    // @ts-ignore TYPE NEEDS FIXING
     sortType: (a, b) => a.original.volumeChangePercent1d - b.original.volumeChangePercent1d,
   },
 ]

--- a/src/features/analytics/Pairs/PairTabs.tsx
+++ b/src/features/analytics/Pairs/PairTabs.tsx
@@ -81,6 +81,7 @@ const tabs = [
   },
 ]
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function PairTabs({ currentType, setType }): JSX.Element {
   return (
     <>

--- a/src/features/analytics/Tokens/Token/CurrencyCard.tsx
+++ b/src/features/analytics/Tokens/Token/CurrencyCard.tsx
@@ -12,6 +12,7 @@ export default function CurrencyCard({ token, symbol }: CurrencyCardProps): JSX.
   return (
     <div className="p-3 rounded w-min sm:w-full bg-dark-900">
       <div className="flex flex-row items-center space-x-4">
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <CurrencyLogo currency={currency} size={40} />
         <div className="hidden text-lg font-bold whitespace-nowrap sm:block text-high-emphesis">{symbol}</div>
       </div>

--- a/src/features/analytics/Tokens/Token/TopFarmsList.tsx
+++ b/src/features/analytics/Tokens/Token/TopFarmsList.tsx
@@ -42,6 +42,7 @@ function FarmListname({ pair }: FarmListNameProps): JSX.Element {
 
   return (
     <div className="flex items-center">
+      {/*@ts-ignore TYPE NEEDS FIXING*/}
       <DoubleCurrencyLogo currency0={token0} currency1={token1} size={28} />
       <div className="ml-3 font-bold text-high-emphesis">
         {pair.token0.symbol}-{pair.token1.symbol}
@@ -56,6 +57,7 @@ export default function TopFarmsList({ farms }: TopFarmsListProps): JSX.Element 
       {
         Header: 'Token Pair',
         accessor: 'pair',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => <FarmListname pair={props.value} />,
         disableSortBy: true,
         align: 'left',
@@ -63,12 +65,14 @@ export default function TopFarmsList({ farms }: TopFarmsListProps): JSX.Element 
       {
         Header: 'ROI (1Y)',
         accessor: 'roi',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => formatPercent(props.value),
         align: 'right',
       },
       {
         Header: 'Rewards',
         accessor: 'rewards',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => props.value,
       },
     ],

--- a/src/features/analytics/Tokens/TokenList.tsx
+++ b/src/features/analytics/Tokens/TokenList.tsx
@@ -40,6 +40,7 @@ function TokenListName({ token }: TokenListNameProps): JSX.Element {
   return (
     <>
       <div className="flex items-center">
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <CurrencyLogo className="rounded-full" currency={currency} size={40} />
         <div className="ml-4 text-lg font-bold text-high-emphesis">{token.symbol}</div>
       </div>

--- a/src/features/analytics/hooks/useTokensAnalytics.ts
+++ b/src/features/analytics/hooks/useTokensAnalytics.ts
@@ -45,8 +45,11 @@ export default function useTokensAnalytics() {
 
   return useMemo(
     () =>
+      // @ts-ignore TYPE NEEDS FIXING
       (loadState === 'loaded' ? tokens : tokensInitial)?.map((token) => {
+        // @ts-ignore TYPE NEEDS FIXING
         const token1d = (loadState === 'loaded' ? tokens1d : tokens1dInitial)?.find((p) => token.id === p.id) ?? token
+        // @ts-ignore TYPE NEEDS FIXING
         const token1w = (loadState === 'loaded' ? tokens1w : tokens1wInitial)?.find((p) => token.id === p.id) ?? token
 
         return {
@@ -64,6 +67,7 @@ export default function useTokensAnalytics() {
           graph: token.dayData
             .slice(0)
             .reverse()
+            // @ts-ignore TYPE NEEDS FIXING
             .map((day, i) => ({ x: i, y: Number(day.priceUSD) })),
         }
       }),

--- a/src/features/inari/Button.tsx
+++ b/src/features/inari/Button.tsx
@@ -28,6 +28,7 @@ const InariButton: FC<InariButtonProps> = ({ children, ...rest }) => {
 
   // Get permit to send with execute
   const handleGetPermit = useCallback(async () => {
+    // @ts-ignore TYPE NEEDS FIXING
     await bentoApproveCallback.getPermit()
   }, [bentoApproveCallback])
 
@@ -68,6 +69,7 @@ const InariButton: FC<InariButtonProps> = ({ children, ...rest }) => {
     return (
       <>
         <Button {...rest} disabled>
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           <Dots>{i18n._(t`Approving Inari to spend ${approveCallback[2].currency.symbol}`)}</Dots>
         </Button>
         {approveFlow}
@@ -78,6 +80,7 @@ const InariButton: FC<InariButtonProps> = ({ children, ...rest }) => {
     return (
       <>
         <Button {...rest} color="pink" onClick={approveCallback[1]}>
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           {i18n._(t`Approve Inari to spend ${approveCallback[2].currency.symbol}`)}
         </Button>
         {approveFlow}

--- a/src/features/kashi/Borrow.tsx
+++ b/src/features/kashi/Borrow.tsx
@@ -49,14 +49,17 @@ export default function Borrow({ pair }: BorrowProps) {
   const collateralToken = useCurrency(pair.collateral.address) || undefined
 
   // Calculated
+  // @ts-ignore TYPE NEEDS FIXING
   const assetNative = WNATIVE[chainId].address === pair.collateral.address
 
+  // @ts-ignore TYPE NEEDS FIXING
   const ethBalance = useETHBalances(assetNative ? [account] : [])
 
   const collateralBalance = useBentoCollateral
     ? pair.collateral.bentoBalance
     : assetNative
-    ? BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
+    ? // @ts-ignore TYPE NEEDS FIXING
+      BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
     : pair.collateral.balance
 
   const displayUpdateOracle = pair.currentExchangeRate.gt(0) ? updateOracle : true
@@ -74,7 +77,9 @@ export default function Borrow({ pair }: BorrowProps) {
     if (!foundTrade) return { realizedLPFee: undefined, priceImpact: undefined }
 
     const realizedLpFeePercent = computeRealizedLPFeePercent(foundTrade)
+    // @ts-ignore TYPE NEEDS FIXING
     const realizedLPFee = foundTrade.inputAmount.multiply(realizedLpFeePercent)
+    // @ts-ignore TYPE NEEDS FIXING
     const priceImpact = foundTrade.priceImpact.subtract(realizedLpFeePercent)
     return { priceImpact, realizedLPFee }
   }, [foundTrade])

--- a/src/features/kashi/Deposit.tsx
+++ b/src/features/kashi/Deposit.tsx
@@ -33,20 +33,24 @@ export default function Deposit({ pair }: any): JSX.Element {
   const [value, setValue] = useState('')
 
   // Calculated
+  // @ts-ignore TYPE NEEDS FIXING
   const assetNative = WNATIVE[chainId].address === pair.asset.address
 
+  // @ts-ignore TYPE NEEDS FIXING
   const ethBalance = useETHBalances(assetNative ? [account] : [])
 
   const balance = useBento
     ? pair.asset.bentoBalance
     : assetNative
-    ? BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
+    ? //  @ts-ignore TYPE NEEDS FIXING
+      BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
     : pair.asset.balance
 
   const max = useBento
     ? pair.asset.bentoBalance
     : assetNative
-    ? BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
+    ? // @ts-ignore TYPE NEEDS FIXING
+      BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
     : pair.asset.balance
 
   const warnings = new Warnings()
@@ -95,6 +99,7 @@ export default function Deposit({ pair }: any): JSX.Element {
     }
     const amount = value.toBigNumber(pair.asset.tokenInfo.decimals)
 
+    // @ts-ignore TYPE NEEDS FIXING
     const deadBalance = await bentoBoxContract.balanceOf(
       pair.asset.address,
       '0x000000000000000000000000000000000000dead'

--- a/src/features/kashi/PairTools.tsx
+++ b/src/features/kashi/PairTools.tsx
@@ -10,6 +10,7 @@ import { formatPercent } from '../../functions'
 import { ZERO } from '../../functions/math'
 import useKashiApproveCallback from '../../hooks/useKashiApproveCallback'
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function PairTools({ pair }) {
   const [, , , , onCook] = useKashiApproveCallback()
 

--- a/src/features/kashi/Repay.tsx
+++ b/src/features/kashi/Repay.tsx
@@ -52,6 +52,7 @@ export default function Repay({ pair }: RepayProps) {
 
   // Calculated
   const assetNative = WNATIVE[chainId || 1].address === pair.asset.address
+  // @ts-ignore TYPE NEEDS FIXING
   const ethBalance = useETHBalances(assetNative ? [account] : [])
 
   console.log({ pair })
@@ -59,7 +60,8 @@ export default function Repay({ pair }: RepayProps) {
   const balance = useBentoRepay
     ? toAmount(pair.asset, pair.asset.bentoBalance)
     : assetNative
-    ? BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
+    ? // @ts-ignore TYPE NEEDS FIXING
+      BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
     : pair.asset.balance
 
   const displayUpdateOracle = pair.currentExchangeRate.gt(0) ? updateOracle : true
@@ -99,7 +101,9 @@ export default function Repay({ pair }: RepayProps) {
     if (!trade) return { realizedLPFee: undefined, priceImpact: undefined }
 
     const realizedLpFeePercent = computeRealizedLPFeePercent(trade)
+    // @ts-ignore TYPE NEEDS FIXING
     const realizedLPFee = trade.inputAmount.multiply(realizedLpFeePercent)
+    // @ts-ignore TYPE NEEDS FIXING
     const priceImpact = trade.priceImpact.subtract(realizedLpFeePercent)
     return { priceImpact, realizedLPFee }
   }, [trade])

--- a/src/features/kashi/Strategy.tsx
+++ b/src/features/kashi/Strategy.tsx
@@ -6,6 +6,7 @@ import Button from '../../components/Button'
 import { formatPercent } from '../../functions'
 import { useBentoBox } from '../../hooks'
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function Strategy({ token }) {
   const { harvest } = useBentoBox()
 

--- a/src/features/kashi/TradeReview.tsx
+++ b/src/features/kashi/TradeReview.tsx
@@ -22,7 +22,9 @@ function TradeReview({
     if (!trade) return { realizedLPFee: undefined, priceImpact: undefined }
 
     const realizedLpFeePercent = computeRealizedLPFeePercent(trade)
+    // @ts-ignore TYPE NEEDS FIXING
     const realizedLPFee = trade.inputAmount.multiply(realizedLpFeePercent)
+    // @ts-ignore TYPE NEEDS FIXING
     const priceImpact = trade.priceImpact.subtract(realizedLpFeePercent)
     return { priceImpact, realizedLPFee }
   }, [trade])

--- a/src/features/kashi/hooks.ts
+++ b/src/features/kashi/hooks.ts
@@ -41,31 +41,44 @@ export function useKashiPairAddresses(): string[] {
   const events = useQueryFilter({
     chainId,
     contract: bentoBoxContract,
+    // @ts-ignore TYPE NEEDS FIXING
     event: bentoBoxContract && bentoBoxContract.filters.LogDeploy(KASHI_ADDRESS[chainId]),
     shouldFetch: useEvents && featureEnabled(Feature.KASHI, chainId),
   })
   const clones = useClones({ chainId, shouldFetch: !useEvents })
   return (
-    useEvents ? events?.map((event) => ({ address: event.args.cloneAddress, data: event.args.data })) : clones
-  )?.reduce((previousValue, currentValue) => {
-    try {
-      const [collateral, asset, oracle, oracleData] = defaultAbiCoder.decode(
-        ['address', 'address', 'address', 'bytes'],
-        currentValue.data
-      )
-      if (
-        BLACKLISTED_TOKENS.includes(collateral) ||
-        BLACKLISTED_TOKENS.includes(asset) ||
-        BLACKLISTED_ORACLES.includes(oracle) ||
-        !validateChainlinkOracleData(chainId, allTokens[collateral], allTokens[asset], oracleData)
-      ) {
-        return previousValue
-      }
-      return [...previousValue, currentValue.address]
-    } catch (error) {
-      return previousValue
-    }
-  }, [])
+    (
+      useEvents
+        ? events?.map((event) => ({
+            address:
+              // @ts-ignore TYPE NEEDS FIXING
+              event.args.cloneAddress,
+            // @ts-ignore TYPE NEEDS FIXING
+            data: event.args.data,
+          }))
+        : clones
+    )
+      // @ts-ignore TYPE NEEDS FIXING
+      ?.reduce((previousValue, currentValue) => {
+        try {
+          const [collateral, asset, oracle, oracleData] = defaultAbiCoder.decode(
+            ['address', 'address', 'address', 'bytes'],
+            currentValue.data
+          )
+          if (
+            BLACKLISTED_TOKENS.includes(collateral) ||
+            BLACKLISTED_TOKENS.includes(asset) ||
+            BLACKLISTED_ORACLES.includes(oracle) ||
+            !validateChainlinkOracleData(chainId, allTokens[collateral], allTokens[asset], oracleData)
+          ) {
+            return previousValue
+          }
+          return [...previousValue, currentValue.address]
+        } catch (error) {
+          return previousValue
+        }
+      }, [])
+  )
 }
 
 export function useKashiPairs(addresses = []) {
@@ -73,8 +86,10 @@ export function useKashiPairs(addresses = []) {
 
   const boringHelperContract = useBoringHelperContract()
 
+  // @ts-ignore TYPE NEEDS FIXING
   const wnative = WNATIVE_ADDRESS[chainId]
 
+  // @ts-ignore TYPE NEEDS FIXING
   const currency = USD[chainId]
 
   const allTokens = useAllTokens()
@@ -82,6 +97,7 @@ export function useKashiPairs(addresses = []) {
   const pollArgs = useMemo(() => [account, addresses], [account, addresses])
 
   // TODO: Replace
+  // @ts-ignore TYPE NEEDS FIXING
   const pollKashiPairs = useSingleCallResult(boringHelperContract, 'pollKashiPairs', pollArgs)?.result?.[0]
 
   const tokens = useMemo<Token[]>(() => {
@@ -89,6 +105,7 @@ export function useKashiPairs(addresses = []) {
       return []
     }
     return Array.from(
+      // @ts-ignore TYPE NEEDS FIXING
       pollKashiPairs?.reduce((previousValue, currentValue) => {
         const asset = allTokens[currentValue.asset]
         const collateral = allTokens[currentValue.collateral]
@@ -102,7 +119,9 @@ export function useKashiPairs(addresses = []) {
   const getBalancesArgs = useMemo(() => [account, tokens.map((token) => token?.address)], [account, tokens])
 
   // TODO: Replace
+  // @ts-ignore TYPE NEEDS FIXING
   const balances = useSingleCallResult(boringHelperContract, 'getBalances', getBalancesArgs)?.result?.[0]?.reduce(
+    // @ts-ignore TYPE NEEDS FIXING
     (previousValue, currentValue) => {
       return { ...previousValue, [currentValue[0]]: currentValue }
     },
@@ -116,6 +135,7 @@ export function useKashiPairs(addresses = []) {
       const balance = balances[currentValue.address]
       const strategy = strategies?.find((strategy) => strategy.token === currentValue.address.toLowerCase())
       const usd = e10(currentValue.decimals).mulDiv(balances[currency.address].rate, balance.rate)
+      // @ts-ignore TYPE NEEDS FIXING
       const symbol = currentValue.address === wnative ? NATIVE[chainId].symbol : currentValue.symbol
       return {
         ...previousValue,
@@ -143,7 +163,9 @@ export function useKashiPairs(addresses = []) {
 
         pair.address = currentValue
         pair.oracle = getOracle(chainId, pair.oracle, pair.oracle.data)
+        // @ts-ignore TYPE NEEDS FIXING
         pair.asset = pairTokens[pair.asset]
+        // @ts-ignore TYPE NEEDS FIXING
         pair.collateral = pairTokens[pair.collateral]
 
         pair.elapsedSeconds = BigNumber.from(Date.now()).div('1000').sub(pair.accrueInfo.lastAccrued)
@@ -302,6 +324,7 @@ export function useKashiPairs(addresses = []) {
 
         pair.safeMaxRemovable = easyAmount(pair.safeMaxRemovable, pair.collateral)
 
+        // @ts-ignore TYPE NEEDS FIXING
         previousValue = [...previousValue, pair]
       }
 
@@ -321,5 +344,6 @@ export function useKashiPairs(addresses = []) {
 }
 
 export function useKashiPair(address: string) {
+  // @ts-ignore TYPE NEEDS FIXING
   return useKashiPairs([getAddress(address)])[0]
 }

--- a/src/features/legacy/limit-order/CurrencySelect.tsx
+++ b/src/features/legacy/limit-order/CurrencySelect.tsx
@@ -36,6 +36,7 @@ const CurrencySelect: FC<CurrencySelectProps> = ({
   const [modalOpen, setModalOpen] = useState(false)
 
   const handleClick = useCallback(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     if (onSelect) setModalOpen(true)
   }, [onSelect])
 

--- a/src/features/legacy/limit-order/LimitOrderButton.tsx
+++ b/src/features/legacy/limit-order/LimitOrderButton.tsx
@@ -81,17 +81,20 @@ const LimitOrderButton: FC<LimitOrderButtonProps> = ({ color, ...rest }) => {
             parsedOutputAmount.wrapped,
             recipient ? recipient : account,
             Math.floor(new Date().getTime() / 1000).toString(),
+            // @ts-ignore TYPE NEEDS FIXING
             endTime.toString()
           )
         : undefined
 
     try {
+      // @ts-ignore TYPE NEEDS FIXING
       await order?.signOrderWithProvider(chainId || 1, library)
       setOpenConfirmationModal(false)
 
       const resp = await order?.send()
       if (resp.success) {
         addPopup({
+          // @ts-ignore TYPE NEEDS FIXING
           txn: { hash: undefined, summary: 'Limit order created', success: true },
         })
 
@@ -102,7 +105,9 @@ const LimitOrderButton: FC<LimitOrderButtonProps> = ({ color, ...rest }) => {
     } catch (e) {
       addPopup({
         txn: {
+          // @ts-ignore TYPE NEEDS FIXING
           hash: undefined,
+          // @ts-ignore TYPE NEEDS FIXING
           summary: `Error: ${e?.response?.data?.data}`,
           success: false,
         },
@@ -122,6 +127,7 @@ const LimitOrderButton: FC<LimitOrderButtonProps> = ({ color, ...rest }) => {
   ])
 
   const deposit = useCallback(async () => {
+    // @ts-ignore TYPE NEEDS FIXING
     const tx = await execute(parsedInputAmount, currency)
     setDepositPending(true)
     await tx.wait()
@@ -156,6 +162,7 @@ const LimitOrderButton: FC<LimitOrderButtonProps> = ({ color, ...rest }) => {
         onClick={deposit}
         {...rest}
       >
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <Dots>{i18n._(t`Depositing ${currency.symbol} into BentoBox`)}</Dots>
       </Button>
     )
@@ -190,6 +197,7 @@ const LimitOrderButton: FC<LimitOrderButtonProps> = ({ color, ...rest }) => {
         loading={approvalState === BentoApprovalState.PENDING}
         disabled={disabled}
         color={disabled ? 'gray' : 'pink'}
+        // @ts-ignore TYPE NEEDS FIXING
         onClick={() => onApprove()}
         {...rest}
       >
@@ -202,6 +210,7 @@ const LimitOrderButton: FC<LimitOrderButtonProps> = ({ color, ...rest }) => {
   )
     button = (
       <Button disabled={disabled} color={disabled ? 'gray' : 'blue'} onClick={deposit} {...rest}>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {i18n._(t`Deposit ${currency.symbol} into BentoBox`)}
       </Button>
     )

--- a/src/features/legacy/limit-order/LimitPriceInputPanel.tsx
+++ b/src/features/legacy/limit-order/LimitPriceInputPanel.tsx
@@ -32,6 +32,7 @@ const LimitPriceInputPanel: FC<LimitPriceInputPanel> = ({ trade }) => {
             !disabled ? 'cursor-pointer hover:border-opacity-100' : ''
           }`}
           onClick={() => {
+            // @ts-ignore TYPE NEEDS FIXING
             dispatch(setLimitPrice(trade.executionPrice.toSignificant(6)))
           }}
         >

--- a/src/features/legacy/limit-order/OrderExpirationDropdown.tsx
+++ b/src/features/legacy/limit-order/OrderExpirationDropdown.tsx
@@ -28,6 +28,7 @@ const OrderExpirationDropdown: FC = () => {
     (e, item) => {
       dispatch(
         setOrderExpiration({
+          // @ts-ignore TYPE NEEDS FIXING
           label: items[item],
           value: item,
         })

--- a/src/features/legacy/liquidity/LiquidityHeader.tsx
+++ b/src/features/legacy/liquidity/LiquidityHeader.tsx
@@ -16,6 +16,7 @@ export default function LiquidityHeader({ input = undefined, output = undefined 
         </a>
       </NavLink>
       <NavLink
+        // @ts-ignore TYPE NEEDS FIXING
         onClick={(event) => {
           if (!output) event.preventDefault()
         }}

--- a/src/features/legacy/liquidity/RemoveLiquidityReceiveDetails.tsx
+++ b/src/features/legacy/liquidity/RemoveLiquidityReceiveDetails.tsx
@@ -43,14 +43,17 @@ export default function RemoveLiquidityReceiveDetails({
                 <Link
                   href={`/remove/${
                     currencyA && currencyEquals(currencyA, WNATIVE[chainId])
-                      ? NATIVE[chainId].symbol
+                      ? // @ts-ignore TYPE NEEDS FIXING
+                        NATIVE[chainId].symbol
                       : currencyId(currencyA)
                   }/${
                     currencyB && currencyEquals(currencyB, WNATIVE[chainId])
-                      ? NATIVE[chainId].symbol
+                      ? // @ts-ignore TYPE NEEDS FIXING
+                        NATIVE[chainId].symbol
                       : currencyId(currencyB)
                   }`}
                 >
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   <a>Receive {NATIVE[chainId].symbol}</a>
                 </Link>
               ) : null}

--- a/src/features/legacy/open-order/CompletedOrders.tsx
+++ b/src/features/legacy/open-order/CompletedOrders.tsx
@@ -97,6 +97,7 @@ const CompletedOrders: FC = () => {
               onChange={(page) => {
                 completed.setPage(page + 1)
               }}
+              // @ts-ignore TYPE NEEDS FIXING
               totalPages={completed.maxPages}
               currentPage={completed.page - 1}
               pageNeighbours={2}

--- a/src/features/legacy/open-order/OpenOrders.tsx
+++ b/src/features/legacy/open-order/OpenOrders.tsx
@@ -22,6 +22,7 @@ const OpenOrders: FC = () => {
   const [hash, setHash] = useState('')
 
   const cancelOrder = async (limitOrder: LimitOrder, summary: string) => {
+    // @ts-ignore TYPE NEEDS FIXING
     const tx = await limitOrderContract.cancelOrder(limitOrder.getTypeHash())
     addTransaction(tx, {
       summary,
@@ -30,6 +31,7 @@ const OpenOrders: FC = () => {
     setHash(tx.hash)
 
     await tx.wait()
+    // @ts-ignore TYPE NEEDS FIXING
     await mutate((data) => ({ ...data }))
   }
 
@@ -116,6 +118,7 @@ const OpenOrders: FC = () => {
             </div>
             <Pagination
               onChange={pending.setPage}
+              // @ts-ignore TYPE NEEDS FIXING
               totalPages={pending.maxPages}
               currentPage={pending.page}
               pageNeighbours={2}

--- a/src/features/meowshi/CurrencyInputPanel.tsx
+++ b/src/features/meowshi/CurrencyInputPanel.tsx
@@ -25,7 +25,9 @@ const CurrencyInputPanel: FC<CurrencyInputPanelProps> = ({ field, meowshiState, 
   const { account } = useActiveWeb3React()
   const { i18n } = useLingui()
   const currency = currencies[field]
+  // @ts-ignore TYPE NEEDS FIXING
   const balance = useTokenBalance(account, currency)
+  // @ts-ignore TYPE NEEDS FIXING
   const inputUSDCValue = useUSDCValue(tryParseAmount(fields[field], currencies[field]))
   const balanceUSDCValue = useUSDCValue(balance)
 
@@ -57,6 +59,7 @@ const CurrencyInputPanel: FC<CurrencyInputPanelProps> = ({ field, meowshiState, 
                   <Typography
                     variant="xs"
                     className="underline cursor-pointer text-blue"
+                    // @ts-ignore TYPE NEEDS FIXING
                     onClick={() => setCurrency(currency === XSUSHI ? SUSHI[ChainId.ETHEREUM] : XSUSHI, field)}
                   >
                     {currencies[field] === SUSHI[ChainId.ETHEREUM] ? i18n._(t`Use xSUSHI`) : i18n._(t`Use SUSHI`)}
@@ -71,6 +74,7 @@ const CurrencyInputPanel: FC<CurrencyInputPanelProps> = ({ field, meowshiState, 
                 <Input.Numeric
                   className="w-full text-2xl leading-4 bg-transparent"
                   id="token-amount-input"
+                  // @ts-ignore TYPE NEEDS FIXING
                   value={fields[field]}
                   onUserInput={(val) => handleInput(val, field)}
                 />
@@ -84,6 +88,7 @@ const CurrencyInputPanel: FC<CurrencyInputPanelProps> = ({ field, meowshiState, 
 
             {showMax && (
               <span
+                // @ts-ignore TYPE NEEDS FIXING
                 onClick={() => handleInput(balance?.toExact(), field)}
                 className="flex items-center justify-center px-2 py-1 text-sm uppercase border border-opacity-50 cursor-pointer border-blue bg-blue text-blue bg-opacity-30 rounded-3xl hover:border-opacity-100"
               >
@@ -96,6 +101,7 @@ const CurrencyInputPanel: FC<CurrencyInputPanelProps> = ({ field, meowshiState, 
           <Typography
             variant="xs"
             component="span"
+            // @ts-ignore TYPE NEEDS FIXING
             onClick={() => handleInput(balance?.toExact(), field)}
             className="cursor-pointer text-primary"
           >

--- a/src/features/meowshi/MeowshiButton.tsx
+++ b/src/features/meowshi/MeowshiButton.tsx
@@ -19,6 +19,7 @@ interface MeowshiButtonProps {
   meowshiState: MeowshiState
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const MeowshiButton: FC<MeowshiButtonProps> = ({ meowshiState }) => {
   const { currencies, meow: doMeow, fields } = meowshiState
   const { i18n } = useLingui()
@@ -28,13 +29,18 @@ const MeowshiButton: FC<MeowshiButtonProps> = ({ meowshiState }) => {
     open: false,
   })
   const { account, chainId } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const sushiBalance = useTokenBalance(account, SUSHI[ChainId.ETHEREUM])
+  // @ts-ignore TYPE NEEDS FIXING
   const xSushiBalance = useTokenBalance(account, XSUSHI)
   const { approvalState, approve, meow, unmeow, meowSushi, unmeowSushi } = useMeowshi(
     currencies[Field.INPUT] === SUSHI[ChainId.ETHEREUM]
   )
+  // @ts-ignore TYPE NEEDS FIXING
   const balance = useTokenBalance(account, currencies[Field.INPUT])
+  // @ts-ignore TYPE NEEDS FIXING
   const parsedInputAmount = tryParseAmount(fields[Field.INPUT], currencies[Field.INPUT])
+  // @ts-ignore TYPE NEEDS FIXING
   const parsedOutputAmount = tryParseAmount(fields[Field.OUTPUT], currencies[Field.OUTPUT])
 
   const closeModal = () => {
@@ -51,30 +57,39 @@ const MeowshiButton: FC<MeowshiButtonProps> = ({ meowshiState }) => {
       txHash: '',
     })
 
+    // @ts-ignore TYPE NEEDS FIXING
     let tx
     if (doMeow) {
       if (currencies[Field.INPUT]?.symbol === 'SUSHI') {
         tx = await meowSushi({
+          // @ts-ignore TYPE NEEDS FIXING
           value: parseUnits(fields[Field.INPUT], sushiBalance.currency.decimals),
+          // @ts-ignore TYPE NEEDS FIXING
           decimals: sushiBalance.currency.decimals,
         })
       }
       if (currencies[Field.INPUT]?.symbol === 'xSUSHI') {
         tx = await meow({
+          // @ts-ignore TYPE NEEDS FIXING
           value: parseUnits(fields[Field.INPUT], sushiBalance.currency.decimals),
+          // @ts-ignore TYPE NEEDS FIXING
           decimals: xSushiBalance.currency.decimals,
         })
       }
     } else {
       if (currencies[Field.OUTPUT]?.symbol === 'SUSHI') {
         tx = await unmeowSushi({
+          // @ts-ignore TYPE NEEDS FIXING
           value: parseUnits(fields[Field.INPUT], sushiBalance.currency.decimals),
+          // @ts-ignore TYPE NEEDS FIXING
           decimals: xSushiBalance.currency.decimals,
         })
       }
       if (currencies[Field.OUTPUT]?.symbol === 'xSUSHI') {
         tx = await unmeow({
+          // @ts-ignore TYPE NEEDS FIXING
           value: parseUnits(fields[Field.INPUT], sushiBalance.currency.decimals),
+          // @ts-ignore TYPE NEEDS FIXING
           decimals: xSushiBalance.currency.decimals,
         })
       }
@@ -84,6 +99,7 @@ const MeowshiButton: FC<MeowshiButtonProps> = ({ meowshiState }) => {
       setModalState((prevState) => ({
         ...prevState,
         attemptingTxn: false,
+        // @ts-ignore TYPE NEEDS FIXING
         txHash: tx.hash,
       }))
     } else {

--- a/src/features/miso/AuctionAdminForm/AuctionAdminFormWhitelistSection/ListOperator.tsx
+++ b/src/features/miso/AuctionAdminForm/AuctionAdminFormWhitelistSection/ListOperator.tsx
@@ -49,6 +49,7 @@ const ListOperator: FC<ListOperatorProps> = ({ auction }) => {
           await tx.wait()
         }
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         setError(e.error.message)
       } finally {
         setPending(false)

--- a/src/features/miso/AuctionAdminForm/AuctionAdminFormWhitelistSection/PermissionListStatusSwitch.tsx
+++ b/src/features/miso/AuctionAdminForm/AuctionAdminFormWhitelistSection/PermissionListStatusSwitch.tsx
@@ -27,6 +27,7 @@ const PermissionListStatusSwitch: FC<PermissionListStatusSwitchProps> = ({ aucti
           await tx.wait()
         }
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         console.error('Changing permission status failed: ', e.message)
       } finally {
         setPending(false)

--- a/src/features/miso/AuctionAdminForm/AuctionAdminFormWhitelistSection/WhitelistUploadField.tsx
+++ b/src/features/miso/AuctionAdminForm/AuctionAdminFormWhitelistSection/WhitelistUploadField.tsx
@@ -51,6 +51,7 @@ const WhitelistUploadField: FC<WhitelistUploadFieldProps> = ({ auction }) => {
         await tx.wait()
       }
     } catch (e) {
+      // @ts-ignore TYPE NEEDS FIXING
       console.error('Updating point list failed: ', e.message)
     } finally {
       setPending(false)

--- a/src/features/miso/AuctionAdminForm/AuctionPaymentCurrencyField.tsx
+++ b/src/features/miso/AuctionAdminForm/AuctionPaymentCurrencyField.tsx
@@ -21,6 +21,7 @@ const AuctionPaymentCurrencyField: FC<AuctionPaymentCurrencyFieldProps> = ({ nam
   const { i18n } = useLingui()
   const { getValues, setValue } = useFormContext()
   const paymentTokenAddress = useWatch({ name })
+  // @ts-ignore TYPE NEEDS FIXING
   const token = useToken(paymentTokenAddress) ?? NATIVE[chainId || 1]
 
   if (!chainId) return <></>
@@ -40,6 +41,7 @@ const AuctionPaymentCurrencyField: FC<AuctionPaymentCurrencyFieldProps> = ({ nam
             activeClassName="border-purple"
             className="!bg-none px-5 !py-2.5"
           >
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {NATIVE[chainId].symbol}
           </ToggleButtonGroup.Button>
           <ToggleButtonGroup.Button

--- a/src/features/miso/AuctionAdminForm/BannedCountries.tsx
+++ b/src/features/miso/AuctionAdminForm/BannedCountries.tsx
@@ -19,9 +19,11 @@ const BannedCountriesFormField: FC = () => {
   const values =
     getValues('bannedCountries')
       ?.split(',')
+      // @ts-ignore TYPE NEEDS FIXING
       .filter((el) => el !== '') || []
 
   const deleteCountry = useCallback(
+    // @ts-ignore TYPE NEEDS FIXING
     (values, value) => setValue('bannedCountries', values?.filter((el) => el !== value).join(',')),
     [setValue]
   )
@@ -58,6 +60,7 @@ const BannedCountriesFormField: FC = () => {
             'flex flex-wrap gap-2 min-h-[42px] relative w-full py-2 pl-3 pr-10 text-left cursor-pointer'
           )}
         >
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           {values?.map((el, index) => {
             return (
               <Chip

--- a/src/features/miso/AuctionAdminForm/index.tsx
+++ b/src/features/miso/AuctionAdminForm/index.tsx
@@ -56,6 +56,7 @@ const AuctionAdminForm: FC<AuctionAdminFormProps> = ({ auction }) => {
   const { editDocuments, cancelAuction } = useAuctionEdit(auction.auctionInfo.addr, auction.template)
 
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     const subscription = watch((data: IFormInputs) => {
       setExampleAuction(
         (prevAuction) =>
@@ -74,6 +75,7 @@ const AuctionAdminForm: FC<AuctionAdminFormProps> = ({ auction }) => {
           })
       )
     })
+    // @ts-ignore TYPE NEEDS FIXING
     return () => subscription.unsubscribe()
   }, [watch])
 
@@ -82,7 +84,9 @@ const AuctionAdminForm: FC<AuctionAdminFormProps> = ({ auction }) => {
       const currentDocs = { ...auction.auctionDocuments }
       const newDocs = { ...data }
       const diff = Object.entries(newDocs).reduce<DocumentInput[]>((acc, [k, v]) => {
+        // @ts-ignore TYPE NEEDS FIXING
         const _ = currentDocs[k] === undefined ? '' : currentDocs[k]
+        // @ts-ignore TYPE NEEDS FIXING
         if (_ !== newDocs[k]) {
           acc.push({ name: k, data: v })
         }

--- a/src/features/miso/AuctionAdminForm/validators.ts
+++ b/src/features/miso/AuctionAdminForm/validators.ts
@@ -19,6 +19,7 @@ export const isAddressValidator: Validator = async (data) => {
   return true
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const pipeline = async (data: ValidatorData, validators: Validator[], resolve, reject) => {
   // Always set field on input
   resolve()
@@ -45,6 +46,7 @@ export const pipeline = async (data: ValidatorData, validators: Validator[], res
     // Reset error
     reject()
   } catch (e) {
+    // @ts-ignore TYPE NEEDS FIXING
     reject(e.message)
   }
 }
@@ -54,11 +56,13 @@ export const testImage = (url?: string, timeout?: number) =>
     console.log('hi')
     timeout = timeout || 5000
     let timedOut = false
+    // @ts-ignore TYPE NEEDS FIXING
     let timer
     const img = new Image()
 
     img.onerror = img.onabort = function () {
       if (!timedOut) {
+        // @ts-ignore TYPE NEEDS FIXING
         clearTimeout(timer)
         res('error')
       }
@@ -66,6 +70,7 @@ export const testImage = (url?: string, timeout?: number) =>
 
     img.onload = function () {
       if (!timedOut) {
+        // @ts-ignore TYPE NEEDS FIXING
         clearTimeout(timer)
         res('success')
       }

--- a/src/features/miso/AuctionCard/index.tsx
+++ b/src/features/miso/AuctionCard/index.tsx
@@ -107,10 +107,12 @@ const AuctionCard: FC<{ auction?: Auction; link?: boolean }> = ({ auction, link 
             <div className="flex gap-3">
               <AuctionIcon auctionTemplate={auction.template} width={18} height={14} />
               <Typography variant="xs" weight={700}>
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {AuctionTitleByTemplateId(i18n)[auction.template]}
               </Typography>
             </div>
             <QuestionHelper
+              // @ts-ignore TYPE NEEDS FIXING
               text={AuctionHelperTextByTemplateId(i18n)[auction.template]}
               icon={<SolidQuestionMarkCircleIcon width={12} height={12} />}
             />
@@ -138,6 +140,7 @@ const AuctionCard: FC<{ auction?: Auction; link?: boolean }> = ({ auction, link 
                 {i18n._(t`Current Token Price`)}
               </Typography>
               <QuestionHelper
+                // @ts-ignore TYPE NEEDS FIXING
                 text={AuctionPriceHelperTextByTemplateId(i18n)[auction.template]}
                 icon={
                   <SolidQuestionMarkCircleIcon
@@ -170,6 +173,7 @@ const AuctionCard: FC<{ auction?: Auction; link?: boolean }> = ({ auction, link 
                   {i18n._(t`Auction Price`)}
                 </Typography>
                 <QuestionHelper
+                  // @ts-ignore TYPE NEEDS FIXING
                   text={AuctionHelperTextByTemplateId(i18n)[auction.template]}
                   icon={<SolidQuestionMarkCircleIcon width={12} height={12} />}
                 />

--- a/src/features/miso/AuctionChart/AuctionChartCrowdsale.tsx
+++ b/src/features/miso/AuctionChart/AuctionChartCrowdsale.tsx
@@ -5,6 +5,7 @@ import { classNames } from 'app/functions'
 import useInterval from 'app/hooks/useInterval'
 import useTextWidth from 'app/hooks/useTextWidth'
 import { FC, useState } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import AutoSizer from 'react-virtualized-auto-sizer'
 
 import { PriceIndicator } from './PriceIndicator'
@@ -39,6 +40,7 @@ const AuctionChartCrowdsale: FC<AuctionChartCrowdsaleProps> = ({ auction, prices
   return (
     <div className={classNames('relative w-full h-full', minHeight)}>
       <AutoSizer>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {({ width, height }) => {
           const remainingHeight = prices ? height - bottomHeight : height
           const currentX = paddingX + (width - 2 * paddingX) * progression

--- a/src/features/miso/AuctionChart/AuctionChartDutch.tsx
+++ b/src/features/miso/AuctionChart/AuctionChartDutch.tsx
@@ -5,6 +5,7 @@ import { classNames } from 'app/functions'
 import useInterval from 'app/hooks/useIntervalTransaction'
 import useTextWidth from 'app/hooks/useTextWidth'
 import { FC, useState } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import AutoSizer from 'react-virtualized-auto-sizer'
 
 import { PriceIndicator } from './PriceIndicator'
@@ -47,6 +48,7 @@ const AuctionChartDutch: FC<AuctionChartDutchProps> = ({ auction, prices, showPr
   return (
     <div className={classNames('relative w-full h-full', minHeight)}>
       <AutoSizer>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {({ width, height }) => {
           const remainingHeight = prices ? height - bottomHeight : height
           const currentX = paddingX + (width - 2 * paddingX) * progression

--- a/src/features/miso/AuctionChart/PriceIndicator.tsx
+++ b/src/features/miso/AuctionChart/PriceIndicator.tsx
@@ -66,6 +66,7 @@ export const PriceIndicator: FC<{
         x={orientation === 'bottom' ? tooltipBottomPositionX : tooltipTopPositionX}
         y={orientation === 'bottom' ? tooltipBottomPositionY : tooltipTopPositionY}
       >
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <QuestionHelper text={AuctionPriceHelperTextByTemplateId(i18n)[auction.template]}>
           <span>
             <QuestionMarkCircleIcon width={12} height={12} className="ml-0 text-secondary mb-[4px] text-dark-400" />

--- a/src/features/miso/AuctionCommitter/index.tsx
+++ b/src/features/miso/AuctionCommitter/index.tsx
@@ -50,6 +50,7 @@ const AuctionCommitter: FC<AuctionCommitterProps> = ({ auction }) => {
   const overSpend =
     auction && whitelistedAmount && auction.totalTokensCommitted?.add(inputAmount).greaterThan(whitelistedAmount)
   const notEnoughBalance = balance && inputAmount && inputAmount.greaterThan(balance)
+  // @ts-ignore TYPE NEEDS FIXING
   let error
 
   if (inputAmount.equalTo(ZERO)) error = i18n._(t`Enter amount`)
@@ -109,6 +110,7 @@ const AuctionCommitter: FC<AuctionCommitterProps> = ({ auction }) => {
                 onClick={() => setReview(true)}
                 disabled={
                   inputAmount.equalTo(ZERO) ||
+                  // @ts-ignore TYPE NEEDS FIXING
                   error ||
                   !!(notWhitelisted || notEnoughBalance || overSpend) ||
                   auction.status !== AuctionStatus.LIVE
@@ -118,6 +120,7 @@ const AuctionCommitter: FC<AuctionCommitterProps> = ({ auction }) => {
               >
                 <div className="flex flex-col items-center gap-1">
                   <Typography className="text-white" weight={700}>
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     {error ? error : i18n._(t`Commit`)}
                   </Typography>
                   {whitelist && (

--- a/src/features/miso/AuctionCreationForm/AuctionCreationFormGeneralDetails/AuctionCreationFormBatchAuction.tsx
+++ b/src/features/miso/AuctionCreationForm/AuctionCreationFormGeneralDetails/AuctionCreationFormBatchAuction.tsx
@@ -17,6 +17,7 @@ const AuctionCreationFormBatchAuction: FC<AuctionCreationFormBatchAuctionProps> 
   const { i18n } = useLingui()
   const { watch } = useFormContext<AuctionCreationFormInput>()
   const data = watch()
+  // @ts-ignore TYPE NEEDS FIXING
   const paymentToken = useToken(data.paymentCurrencyAddress) ?? NATIVE[chainId || 1]
 
   return (

--- a/src/features/miso/AuctionCreationForm/AuctionCreationFormGeneralDetails/AuctionCreationFormCrowdsale.tsx
+++ b/src/features/miso/AuctionCreationForm/AuctionCreationFormGeneralDetails/AuctionCreationFormCrowdsale.tsx
@@ -18,6 +18,7 @@ const AuctionCreationFormCrowdsale: FC<AuctionCreationFormCrowdsaleProps> = ({})
   const { i18n } = useLingui()
   const { watch } = useFormContext<AuctionCreationFormInput>()
   const data = watch()
+  // @ts-ignore TYPE NEEDS FIXING
   const paymentToken = useToken(data.paymentCurrencyAddress) ?? NATIVE[chainId || 1]
   const auctionToken = useToken(data.token)
 

--- a/src/features/miso/AuctionCreationForm/AuctionCreationFormGeneralDetails/AuctionCreationFormDutchAuction.tsx
+++ b/src/features/miso/AuctionCreationForm/AuctionCreationFormGeneralDetails/AuctionCreationFormDutchAuction.tsx
@@ -18,6 +18,7 @@ const AuctionCreationFormDutchAuction: FC<AuctionCreationFormDutchAuctionProps> 
   const { i18n } = useLingui()
   const { watch } = useFormContext<AuctionCreationFormInput>()
   const data = watch()
+  // @ts-ignore TYPE NEEDS FIXING
   const paymentToken = useToken(data.paymentCurrencyAddress) ?? NATIVE[chainId || 1]
   const auctionToken = useToken(data.token)
 

--- a/src/features/miso/AuctionCreationForm/AuctionCreationFormGeneralDetails/AuctionCreationFormTokenAmount.tsx
+++ b/src/features/miso/AuctionCreationForm/AuctionCreationFormGeneralDetails/AuctionCreationFormTokenAmount.tsx
@@ -34,6 +34,7 @@ const AuctionCreationFormTokenAmount: FC<AuctionCreationFormTokenProps> = ({}) =
 
   const [approvalState, approve] = useApproveCallback(
     amount,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOMarket.address : undefined
   )
 

--- a/src/features/miso/AuctionCreationForm/AuctionCreationReviewModal.tsx
+++ b/src/features/miso/AuctionCreationForm/AuctionCreationReviewModal.tsx
@@ -58,6 +58,7 @@ const AuctionCreationModal: FC<AuctionCreationModalProps> = ({ open, onDismiss: 
           await tx.wait()
         }
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         setError(e.error?.message)
       } finally {
         setPending(false)
@@ -68,6 +69,7 @@ const AuctionCreationModal: FC<AuctionCreationModalProps> = ({ open, onDismiss: 
 
   // Subscribe to creation event to get created token ID
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     subscribe('MarketCreated', (owner, address, marketTemplate, { transactionHash }) => {
       if (transactionHash?.toLowerCase() === txHash?.toLowerCase()) {
         setAuctionAddress(address)

--- a/src/features/miso/AuctionCreationForm/index.tsx
+++ b/src/features/miso/AuctionCreationForm/index.tsx
@@ -75,10 +75,12 @@ const schema = yup.object().shape({
     .required('Must enter a valid number'),
   paymentCurrencyAddress: addressValidator.required('Must enter a valid address'),
   fixedPrice: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.CROWDSALE,
     then: yup.number().typeError('Price must be a number').required('Must enter a fixed price'),
   }),
   minimumTarget: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.CROWDSALE,
     then: yup
       .number()
@@ -87,14 +89,17 @@ const schema = yup.object().shape({
       .max(100, 'Can be at most 100%'),
   }),
   minimumRaised: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.BATCH_AUCTION,
     then: yup.number().typeError('Target must be a number').min(0, 'Must be greater than zero'),
   }),
   startPrice: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.DUTCH_AUCTION,
     then: yup.number().typeError('Price must be a number').required('Must enter a start price'),
   }),
   endPrice: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.DUTCH_AUCTION,
     then: yup
       .number()
@@ -140,6 +145,7 @@ const AuctionCreationForm: FC = () => {
 
   // Format data
   const auctionToken = useToken(data.token) ?? undefined
+  // @ts-ignore TYPE NEEDS FIXING
   const paymentToken = useToken(data.paymentCurrencyAddress) ?? NATIVE[chainId || 1]
   const formattedData =
     auctionToken && paymentToken && !isValidating && isValid

--- a/src/features/miso/AuctionCreationWizard/AuctionCreationWizardReviewModal.tsx
+++ b/src/features/miso/AuctionCreationWizard/AuctionCreationWizardReviewModal.tsx
@@ -65,6 +65,7 @@ const AuctionCreationWizardReviewModal: FC<AuctionCreationWizardReviewModalProps
         }
       } catch (e) {
         console.log(e)
+        // @ts-ignore TYPE NEEDS FIXING
         setError(e.error?.message)
       } finally {
         setPending(false)
@@ -75,6 +76,7 @@ const AuctionCreationWizardReviewModal: FC<AuctionCreationWizardReviewModalProps
 
   // Subscribe to creation event to get created token ID
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     subscribe('MarketCreated', (owner, address, marketTemplate, { transactionHash }) => {
       if (transactionHash?.toLowerCase() === txHash?.toLowerCase()) {
         setAuctionAddress(address)

--- a/src/features/miso/AuctionCreationWizard/AuctionDetailsStep/AuctionTypeDetails/BatchAuctionDetails.tsx
+++ b/src/features/miso/AuctionCreationWizard/AuctionDetailsStep/AuctionTypeDetails/BatchAuctionDetails.tsx
@@ -15,6 +15,7 @@ const BatchAuctionDetails: FC = () => {
   const { i18n } = useLingui()
   const { watch } = useFormContext<AuctionCreationWizardInput>()
   const data = watch()
+  // @ts-ignore TYPE NEEDS FIXING
   const paymentToken = useToken(data.paymentCurrencyAddress) ?? NATIVE[chainId || 1]
 
   return (

--- a/src/features/miso/AuctionCreationWizard/AuctionDetailsStep/AuctionTypeDetails/CrowdsaleDetails.tsx
+++ b/src/features/miso/AuctionCreationWizard/AuctionDetailsStep/AuctionTypeDetails/CrowdsaleDetails.tsx
@@ -19,6 +19,7 @@ const CrowdsaleDetails: FC = () => {
   const data = watch()
 
   const auctionToken = new Token(1, AddressZero, 18, data.tokenSymbol, data.tokenName)
+  // @ts-ignore TYPE NEEDS FIXING
   const paymentToken = useToken(data.paymentCurrencyAddress) ?? NATIVE[chainId || 1]
 
   let price: Price<Token, Currency> | undefined

--- a/src/features/miso/AuctionCreationWizard/AuctionDetailsStep/AuctionTypeDetails/DutchAuctionDetails.tsx
+++ b/src/features/miso/AuctionCreationWizard/AuctionDetailsStep/AuctionTypeDetails/DutchAuctionDetails.tsx
@@ -17,6 +17,7 @@ const DutchAuctionDetails: FC = () => {
   const { i18n } = useLingui()
   const { watch } = useFormContext<AuctionCreationWizardInput>()
   const data = watch()
+  // @ts-ignore TYPE NEEDS FIXING
   const paymentToken = useToken(data.paymentCurrencyAddress) ?? NATIVE[chainId || 1]
   const auctionToken = new Token(1, AddressZero, 18, data.tokenSymbol, data.tokenName)
 

--- a/src/features/miso/AuctionCreationWizard/LiquidityLauncherStep.tsx
+++ b/src/features/miso/AuctionCreationWizard/LiquidityLauncherStep.tsx
@@ -24,11 +24,13 @@ const LiquidityLauncherStep: FC = () => {
 
   useEffect(() => {
     const value = Math.round((Number(getValues('liqPercentage')) / 100) * tokenAmount)
+    // @ts-ignore TYPE NEEDS FIXING
     setValue('tokenForLiquidity', value > 0 ? value : undefined)
   }, [getValues, liqPercentage, setValue, tokenAmount])
 
   useEffect(() => {
     const value = Math.round((Number(getValues('tokenForLiquidity')) * 100) / tokenAmount)
+    // @ts-ignore TYPE NEEDS FIXING
     setValue('liqPercentage', value > 0 ? value : undefined)
   }, [getValues, tokenForLiquidity, setValue, tokenAmount])
 

--- a/src/features/miso/AuctionCreationWizard/index.tsx
+++ b/src/features/miso/AuctionCreationWizard/index.tsx
@@ -109,18 +109,22 @@ const schema = yup.object().shape({
     .integer('Must be a whole number')
     .test({
       message: 'Amount of tokens for liquidity seeding must be at least 1 percent of tokens for sale',
+      // @ts-ignore TYPE NEEDS FIXING
       test: (value, ctx) => value * 100 >= ctx.parent.tokenAmount,
     })
     .test({
       message: 'Amount of tokens for liquidity cannot be larger than amount of tokens for sale',
+      // @ts-ignore TYPE NEEDS FIXING
       test: (value, ctx) => value <= ctx.parent.tokenAmount,
     }),
   auctionType: yup.number().required('Must select an auction type'),
   fixedPrice: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.CROWDSALE,
     then: yup.number().typeError('Price must be a number').required('Must enter a fixed price'),
   }),
   minimumTarget: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.CROWDSALE,
     then: yup
       .number()
@@ -130,14 +134,17 @@ const schema = yup.object().shape({
       .integer('Must be a whole number'),
   }),
   minimumRaised: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.BATCH_AUCTION,
     then: yup.number().typeError('Target must be a number').min(0, 'Must be greater than zero'),
   }),
   startPrice: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.DUTCH_AUCTION,
     then: yup.number().typeError('Price must be a number').required('Must enter a start price'),
   }),
   endPrice: yup.number().when('auctionType', {
+    // @ts-ignore TYPE NEEDS FIXING
     is: (value) => value === AuctionTemplate.DUTCH_AUCTION,
     then: yup
       .number()
@@ -178,6 +185,7 @@ const AuctionCreationWizard: FC = () => {
 
   const data = watch()
 
+  // @ts-ignore TYPE NEEDS FIXING
   const paymentToken = useToken(data.paymentCurrencyAddress) ?? NATIVE[chainId || 1]
   const formattedData =
     paymentToken && !isValidating && isValid ? formatCreationFormData(data, paymentToken) : undefined

--- a/src/features/miso/AuctionDocuments/index.tsx
+++ b/src/features/miso/AuctionDocuments/index.tsx
@@ -43,6 +43,7 @@ const AuctionDocuments: FC<AuctionDocumentsProps> = ({ auction }) => {
         <div className="flex gap-1.5">
           <AuctionIcon auctionTemplate={auction.template} width={18} />
           <Typography variant="sm" weight={700} className="text-secondary">
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {AuctionTitleByTemplateId(i18n)[auction.template]}
           </Typography>
         </div>
@@ -70,6 +71,7 @@ const AuctionDocuments: FC<AuctionDocumentsProps> = ({ auction }) => {
           {i18n._(t`Technical Information`)}
         </Typography>
         <div className="flex gap-4">
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           {info.filter((el) => !!documents?.[el]).length === 0 && (
             <Typography variant="sm" className="italic">
               {i18n._(t`No documents provided`)}
@@ -112,6 +114,7 @@ const AuctionDocuments: FC<AuctionDocumentsProps> = ({ auction }) => {
           {i18n._(t`Socials`)}
         </Typography>
         <div className="flex gap-5 items-center">
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           {info.filter((el) => !!documents?.[el]).length === 0 && (
             <Typography variant="sm" className="italic">
               {i18n._(t`No socials provided`)}

--- a/src/features/miso/AuctionHeader/index.tsx
+++ b/src/features/miso/AuctionHeader/index.tsx
@@ -144,7 +144,8 @@ const AuctionHeader: FC<AuctionHeaderProps> = ({ auction }) => {
               text={
                 auction.template === AuctionTemplate.DUTCH_AUCTION
                   ? AuctionHelperTextByTemplateId(i18n)[auction.template]
-                  : AuctionPriceHelperTextByTemplateId(i18n)[auction.template]
+                  : // @ts-ignore TYPE NEEDS FIXING
+                    AuctionPriceHelperTextByTemplateId(i18n)[auction.template]
               }
               icon={<SolidQuestionMarkCircleIcon width={12} height={12} className="text-secondary" />}
             />
@@ -153,6 +154,7 @@ const AuctionHeader: FC<AuctionHeaderProps> = ({ auction }) => {
           <div className="flex justify-end items-baseline w-full gap-1">
             {auction.template === AuctionTemplate.DUTCH_AUCTION ? (
               <AuctionCardPrice auction={auction}>
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {({ price }) => {
                   return (
                     <>

--- a/src/features/miso/AuctionStats/index.tsx
+++ b/src/features/miso/AuctionStats/index.tsx
@@ -70,6 +70,7 @@ const AuctionStats: FC<AuctionStatsProps> = ({ auction }) => {
             <div className="flex items-center justify-end">
               {i18n._(t`Current Token Price`)}
               <QuestionHelper
+                // @ts-ignore TYPE NEEDS FIXING
                 text={AuctionPriceHelperTextByTemplateId(i18n)[auction.template]}
                 icon={<SolidQuestionMarkCircleIcon width={12} height={12} className="text-secondary" />}
               />

--- a/src/features/miso/AuctionTabs/AuctionBidsTab.tsx
+++ b/src/features/miso/AuctionTabs/AuctionBidsTab.tsx
@@ -12,6 +12,7 @@ import { classNames, getExplorerLink, shortenAddress, shortenString } from 'app/
 import { useActiveWeb3React } from 'app/services/web3'
 import { useBlockNumber } from 'app/state/application/hooks'
 import React, { FC, useMemo, useState } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import { useFlexLayout, usePagination, useSortBy, useTable } from 'react-table'
 
 export const useCommitmentTableConfig = (commitments?: AuctionCommitment[]) => {
@@ -153,8 +154,10 @@ const AuctionBidsTab: FC<AuctionBidsTabProps> = ({ auction, active }) => {
       <div className="flex flex-col gap-2">
         <div {...getTableProps()} className="w-full">
           <div className="mb-3">
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {headerGroups.map((headerGroup, i) => (
               <div {...headerGroup.getHeaderGroupProps()} key={i}>
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {headerGroup.headers.map((column, i) => (
                   <Typography
                     weight={700}
@@ -169,10 +172,12 @@ const AuctionBidsTab: FC<AuctionBidsTabProps> = ({ auction, active }) => {
             ))}
           </div>
           <div {...getTableBodyProps()}>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {page.map((row, i) => {
               prepareRow(row)
               return (
                 <div {...row.getRowProps()} key={i} className="space-y-4">
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {row.cells.map((cell, i) => {
                     return (
                       <Typography

--- a/src/features/miso/CommitReviewModal.tsx
+++ b/src/features/miso/CommitReviewModal.tsx
@@ -74,6 +74,7 @@ const CommitReviewStandardModal: FC<CommitReviewStandardModalProps> = ({
         summary: i18n._(t`Committed ${amount?.toSignificant(6)} ${amount.currency.symbol}`),
       })
     } catch (e) {
+      // @ts-ignore TYPE NEEDS FIXING
       setError(e.error?.message)
     } finally {
       setAttemptingTxn(false)
@@ -106,6 +107,7 @@ const CommitReviewStandardModal: FC<CommitReviewStandardModalProps> = ({
                     <div className="flex gap-1.5">
                       <AuctionIcon auctionTemplate={auction.template} width={18} />
                       <Typography variant="sm" className="text-secondary">
+                        {/*@ts-ignore TYPE NEEDS FIXING*/}
                         {AuctionTitleByTemplateId(i18n)[auction.template]}
                       </Typography>
                     </div>

--- a/src/features/miso/LiquidityLauncherCreationForm/LiquidityLauncherCreationReviewModal.tsx
+++ b/src/features/miso/LiquidityLauncherCreationForm/LiquidityLauncherCreationReviewModal.tsx
@@ -60,6 +60,7 @@ const LiquidityLauncherCreationModal: FC<LiquidityLauncherCreationModalProps> = 
           await tx.wait()
         }
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         setError(e.error?.message)
       } finally {
         setPending(false)
@@ -70,6 +71,7 @@ const LiquidityLauncherCreationModal: FC<LiquidityLauncherCreationModalProps> = 
 
   // Subscribe to creation event to get created pointlist ID
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     subscribe('LauncherCreated', (owner, address, launcherTemplate, { transactionHash }) => {
       if (transactionHash?.toLowerCase() === txHash?.toLowerCase()) {
         setLiqLauncherAddress(address)

--- a/src/features/miso/PointlistCreationForm/PointlistCreationReviewModal.tsx
+++ b/src/features/miso/PointlistCreationForm/PointlistCreationReviewModal.tsx
@@ -29,6 +29,7 @@ const PointlistCreationModal: FC<PointlistCreationModalProps> = ({ open, onDismi
   const [listAddress, setListAddress] = useState<string>()
   const [txHash, setTxHash] = useState<string>()
   const [pending, setPending] = useState(false)
+  // @ts-ignore TYPE NEEDS FIXING
   const token = useToken(data.paymentTokenAddress) ?? NATIVE[chainId || 1]
   const [error, setError] = useState<string>()
 
@@ -73,6 +74,7 @@ const PointlistCreationModal: FC<PointlistCreationModalProps> = ({ open, onDismi
           await tx.wait()
         }
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         setError(e.error?.message)
       } finally {
         setPending(false)
@@ -83,6 +85,7 @@ const PointlistCreationModal: FC<PointlistCreationModalProps> = ({ open, onDismi
 
   // Subscribe to creation event to get created pointlist ID
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     subscribe('PointListDeployed', (operator, address, pointList, owner, { transactionHash }) => {
       if (transactionHash?.toLowerCase() === txHash?.toLowerCase()) {
         setListAddress(address)

--- a/src/features/miso/PointlistCreationForm/index.tsx
+++ b/src/features/miso/PointlistCreationForm/index.tsx
@@ -50,6 +50,7 @@ const PointlistCreationFormSetup: FC = () => {
   } = methods
 
   const data = watch()
+  // @ts-ignore TYPE NEEDS FIXING
   const token = useToken(data.paymentTokenAddress) ?? NATIVE[chainId || 1]
 
   const onSubmit = () => setOpen(true)

--- a/src/features/miso/TokenCreationForm/TokenCreationFormGeneralDetails.tsx
+++ b/src/features/miso/TokenCreationForm/TokenCreationFormGeneralDetails.tsx
@@ -38,6 +38,7 @@ const TokenCreationFormGeneralDetails: FC<TokenCreationFormGeneralDetailsProps> 
           label={i18n._(t`Initial Supply*`)}
           helperText={
             tokenTypeAddress ===
+            // @ts-ignore TYPE NEEDS FIXING
             (chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.FixedToken.address : undefined)
               ? i18n._(
                   t`This will be the initial supply of your token. Because your token type is set to fixed. This value will be final and immutable`

--- a/src/features/miso/TokenCreationForm/TokenCreationReviewModal.tsx
+++ b/src/features/miso/TokenCreationForm/TokenCreationReviewModal.tsx
@@ -51,6 +51,7 @@ const TokenCreationModal: FC<TokenCreationModalProps> = ({ open, onDismiss: _onD
           await tx.wait()
         }
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         setError(e.error?.message)
       } finally {
         setPending(false)
@@ -61,6 +62,7 @@ const TokenCreationModal: FC<TokenCreationModalProps> = ({ open, onDismiss: _onD
 
   // Subscribe to creation event to get created token ID
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     subscribe('TokenCreated', (owner, tokenAddress, tokenTemplate, { transactionHash }) => {
       if (transactionHash?.toLowerCase() === txHash?.toLowerCase()) {
         setTokenAddress(tokenAddress)
@@ -88,6 +90,7 @@ const TokenCreationModal: FC<TokenCreationModalProps> = ({ open, onDismiss: _onD
                     {i18n._(t`Type`)}
                   </Typography>
                   <Typography weight={700} variant="sm" className="text-high-emphesis">
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     {templateIdToLabel(tokenTemplateMap?.[data.tokenTypeAddress])}
                   </Typography>
                 </div>

--- a/src/features/miso/TokenCreationForm/index.tsx
+++ b/src/features/miso/TokenCreationForm/index.tsx
@@ -41,6 +41,7 @@ const TokenCreationForm: FC = ({}) => {
   const methods = useForm<TokenCreationFormInput>({
     resolver: yupResolver(schema),
     defaultValues: {
+      // @ts-ignore TYPE NEEDS FIXING
       tokenTypeAddress: chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.FixedToken.address : undefined,
     },
     reValidateMode: 'onChange',

--- a/src/features/miso/WhitelistUpload.tsx
+++ b/src/features/miso/WhitelistUpload.tsx
@@ -20,6 +20,7 @@ const WhitelistUpload: FC<WhitelistUploadProps> = ({ disabled, onChange, value }
 
   const onDrop = useCallback(
     (acceptedFiles) => {
+      // @ts-ignore TYPE NEEDS FIXING
       acceptedFiles.forEach((file) => {
         const reader = new FileReader()
         reader.onload = () => {

--- a/src/features/miso/context/Auction.ts
+++ b/src/features/miso/context/Auction.ts
@@ -19,6 +19,7 @@ export class Auction {
   public readonly launcherInfo?: RawLauncherInfo
   public readonly auctionDocuments: AuctionDocument
   public readonly pointListAddress: string
+  // @ts-ignore TYPE NEEDS FIXING
   public readonly auctionLauncherAddress: string
   public readonly status: AuctionStatus
 

--- a/src/features/miso/context/hooks/useAuctionCreate.ts
+++ b/src/features/miso/context/hooks/useAuctionCreate.ts
@@ -21,19 +21,27 @@ const useAuctionCreate = () => {
   const { map: tokenTemplateMap } = useTokenTemplateMap()
   const { map: launcherTemplateMap } = useLiquidityLauncherTemplateMap()
   const marketFactory = useContract(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOMarket.address : undefined,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOMarket.abi : undefined
   )
   const tokenFactory = useContract(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOTokenFactory.address : undefined,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOTokenFactory.abi : undefined
   )
   const launcherFactory = useContract(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOLauncher.address : undefined,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOLauncher.abi : undefined
   )
   const recipeContract = useContract(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.AuctionCreation.address : undefined,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.AuctionCreation.abi : undefined
   )
 

--- a/src/features/miso/context/hooks/useAuctionDocuments.ts
+++ b/src/features/miso/context/hooks/useAuctionDocuments.ts
@@ -7,7 +7,9 @@ export interface DocumentInput {
   data: string
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const arrayToMap = (result) =>
+  // @ts-ignore TYPE NEEDS FIXING
   result.reduce((acc, cur) => {
     acc[cur.name] = cur.data
     return acc

--- a/src/features/miso/context/hooks/useAuctionEdit.ts
+++ b/src/features/miso/context/hooks/useAuctionEdit.ts
@@ -18,11 +18,13 @@ export const useAuctionEdit = (
 
   const liquidityLauncherContract = useContract(
     address,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.PostAuctionLauncher.abi : undefined
   )
 
   const pointListContract = useContract(
     listAddress,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.PointList.abi : undefined
   )
 
@@ -51,6 +53,7 @@ export const useAuctionEdit = (
 
         return tx
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         console.error('set document error:', e.message)
       }
     },
@@ -66,6 +69,7 @@ export const useAuctionEdit = (
 
       return tx
     } catch (e) {
+      // @ts-ignore TYPE NEEDS FIXING
       console.error('cancel auction error:', e.message)
     }
   }, [addTransaction, auctionContract])
@@ -109,6 +113,7 @@ export const useAuctionEdit = (
         addTransaction(tx, { summary: 'Set permission list' })
         return tx
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         console.error('set permission list error: ', e.message)
       }
     },
@@ -124,6 +129,7 @@ export const useAuctionEdit = (
         addTransaction(tx, { summary: status ? 'Enable permission list' : 'Disable permission list' })
         return tx
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         console.error('set permission list status error:', e.message)
       }
     },
@@ -139,6 +145,7 @@ export const useAuctionEdit = (
         addTransaction(tx, { summary: 'Set point list' })
         return tx
       } catch (e) {
+        // @ts-ignore TYPE NEEDS FIXING
         console.error('set point list error:', e.message)
       }
     },

--- a/src/features/miso/context/hooks/useAuctionInfo.ts
+++ b/src/features/miso/context/hooks/useAuctionInfo.ts
@@ -11,7 +11,9 @@ import { useMemo } from 'react'
 
 const AUCTION_INTERFACE = new Interface(BASE_AUCTION_ABI)
 
+// @ts-ignore TYPE NEEDS FIXING
 const arrayToMap = (result) =>
+  // @ts-ignore TYPE NEEDS FIXING
   result?.reduce((acc, cur) => {
     acc[cur.name] = cur.data
     return acc
@@ -113,6 +115,7 @@ export const useAuctionLauncherDetails = (
   const { chainId } = useActiveWeb3React()
   const launcher = useContract(
     launcherAddress,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.PostAuctionLauncher.abi : undefined
   )
   const callsData = useMemo(

--- a/src/features/miso/context/hooks/useAuctionLiquidityLauncher.ts
+++ b/src/features/miso/context/hooks/useAuctionLiquidityLauncher.ts
@@ -15,7 +15,9 @@ export const useAuctionLiquidityLauncher = () => {
   const addTransaction = useTransactionAdder()
   const factory = useFactoryContract()
   const contract = useContract(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOLauncher.address : undefined,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOLauncher.abi : undefined
   )
   const { map: templateMap } = useLiquidityLauncherTemplateMap()

--- a/src/features/miso/context/hooks/useAuctionList.ts
+++ b/src/features/miso/context/hooks/useAuctionList.ts
@@ -11,11 +11,13 @@ export const useAuctionList = (type?: AuctionStatus): RawAuction[] => {
   return useMemo(() => {
     if (!result || !Array.isArray(result) || !(result.length > 0)) return []
 
+    // @ts-ignore TYPE NEEDS FIXING
     let filtered = result[0].filter((el) => !BAD_AUCTIONS.includes(el.addr))
     const currentTimestamp = new Date().getTime()
 
     if (type === AuctionStatus.LIVE) {
       return filtered.filter(
+        // @ts-ignore TYPE NEEDS FIXING
         (auction) =>
           currentTimestamp >= auction.startTime.mul('1000').toNumber() &&
           currentTimestamp < auction.endTime.mul('1000').toNumber() &&
@@ -23,10 +25,12 @@ export const useAuctionList = (type?: AuctionStatus): RawAuction[] => {
       )
     } else if (type === AuctionStatus.UPCOMING) {
       return filtered.filter(
+        // @ts-ignore TYPE NEEDS FIXING
         (auction) => currentTimestamp < auction.startTime.mul('1000').toNumber() && !auction.finalized
       )
     } else if (type === AuctionStatus.FINISHED) {
       return filtered.filter(
+        // @ts-ignore TYPE NEEDS FIXING
         (auction) => currentTimestamp > auction.endTime.mul('1000').toNumber() || auction.finalized
       )
     }

--- a/src/features/miso/context/hooks/useAuctionPointList.ts
+++ b/src/features/miso/context/hooks/useAuctionPointList.ts
@@ -28,6 +28,7 @@ export const useAuctionPointListPoints = (
   const { account, chainId } = useActiveWeb3React()
   const contract = useContract(
     listAddress,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.PointList.abi : undefined
   )
   const { result } = useSingleCallResult(
@@ -45,7 +46,9 @@ export const useAuctionPointListFunctions = () => {
   const { account, chainId } = useActiveWeb3React()
   const addTransaction = useTransactionAdder()
   const contract = useContract(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.ListFactory.address : undefined,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.ListFactory.abi : undefined
   )
 

--- a/src/features/miso/context/hooks/useAuctionTemplateMap.ts
+++ b/src/features/miso/context/hooks/useAuctionTemplateMap.ts
@@ -25,13 +25,21 @@ const useAuctionTemplateMap = () => {
     if (!chainId) return undefined
 
     return {
+      // @ts-ignore TYPE NEEDS FIXING
       [MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.Crowdsale.address]: AuctionTemplate.CROWDSALE,
+      // @ts-ignore TYPE NEEDS FIXING
       [MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.DutchAuction.address]: AuctionTemplate.DUTCH_AUCTION,
+      // @ts-ignore TYPE NEEDS FIXING
       [MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.BatchAuction.address]: AuctionTemplate.BATCH_AUCTION,
+      // @ts-ignore TYPE NEEDS FIXING
       [MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.HyperbolicAuction.address]: AuctionTemplate.HYPERBOLIC_AUCTION,
+      // @ts-ignore TYPE NEEDS FIXING
       [AuctionTemplate.CROWDSALE]: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.Crowdsale,
+      // @ts-ignore TYPE NEEDS FIXING
       [AuctionTemplate.DUTCH_AUCTION]: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.DutchAuction,
+      // @ts-ignore TYPE NEEDS FIXING
       [AuctionTemplate.BATCH_AUCTION]: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.BatchAuction,
+      // @ts-ignore TYPE NEEDS FIXING
       [AuctionTemplate.HYPERBOLIC_AUCTION]: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.HyperbolicAuction,
     }
   }, [chainId])

--- a/src/features/miso/context/hooks/useAuctionToken.ts
+++ b/src/features/miso/context/hooks/useAuctionToken.ts
@@ -11,7 +11,9 @@ const useAuctionToken = () => {
   const { account, chainId } = useActiveWeb3React()
   const addTransaction = useTransactionAdder()
   const contract = useContract(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOTokenFactory.address : undefined,
+    // @ts-ignore TYPE NEEDS FIXING
     chainId ? MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOTokenFactory.abi : undefined
   )
 

--- a/src/features/miso/context/hooks/useLiquidityLauncherTemplateMap.ts
+++ b/src/features/miso/context/hooks/useLiquidityLauncherTemplateMap.ts
@@ -22,9 +22,11 @@ export const useLiquidityLauncherTemplateMap = () => {
     if (!chainId) return undefined
 
     return {
+      // @ts-ignore TYPE NEEDS FIXING
       [MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.PostAuctionLauncher.address]:
         LiquidityLauncherTemplate.PostAuctionLauncher,
       [LiquidityLauncherTemplate.PostAuctionLauncher]:
+        // @ts-ignore TYPE NEEDS FIXING
         MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.PostAuctionLauncher,
     }
   }, [chainId])

--- a/src/features/miso/context/hooks/useTokenTemplateMap.ts
+++ b/src/features/miso/context/hooks/useTokenTemplateMap.ts
@@ -24,11 +24,17 @@ const useTokenTemplateMap = () => {
     if (!chainId) return undefined
 
     return {
+      // @ts-ignore TYPE NEEDS FIXING
       [MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.FixedToken.address]: TokenType.FIXED,
+      // @ts-ignore TYPE NEEDS FIXING
       [MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.SushiToken.address]: TokenType.SUSHI,
+      // @ts-ignore TYPE NEEDS FIXING
       [MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MintableToken.address]: TokenType.MINTABLE,
+      // @ts-ignore TYPE NEEDS FIXING
       [TokenType.FIXED]: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.FixedToken,
+      // @ts-ignore TYPE NEEDS FIXING
       [TokenType.SUSHI]: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.SushiToken,
+      // @ts-ignore TYPE NEEDS FIXING
       [TokenType.MINTABLE]: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MintableToken,
     }
   }, [chainId])

--- a/src/features/miso/context/utils.ts
+++ b/src/features/miso/context/utils.ts
@@ -9,24 +9,28 @@ import {
   RawAuctionInfo,
 } from 'app/features/miso/context/types'
 
+// @ts-ignore TYPE NEEDS FIXING
 export const AuctionStatusById = (i18n) => ({
   1: i18n._(t`LIVE`),
   2: i18n._(t`UPCOMING`),
   3: i18n._(t`FINISHED`),
 })
 
+// @ts-ignore TYPE NEEDS FIXING
 export const AuctionTitleByTemplateId = (i18n) => ({
   1: i18n._(t`Crowdsale`),
   2: i18n._(t`Dutch Auction`),
   3: i18n._(t`Batch Auction`),
 })
 
+// @ts-ignore TYPE NEEDS FIXING
 export const AuctionHelperTextByTemplateId = (i18n) => ({
   1: i18n._(t`Fixed price with fixed amount`),
   2: i18n._(t`Price discovery that linearly declines from ceiling to floor price`),
   3: i18n._(t`Valuation discovery with a minimum threshold and uncapped raise`),
 })
 
+// @ts-ignore TYPE NEEDS FIXING
 export const AuctionPriceHelperTextByTemplateId = (i18n) => ({
   1: i18n._(t`Fixed price, doesn't change over time`),
   2: i18n._(
@@ -36,9 +40,13 @@ export const AuctionPriceHelperTextByTemplateId = (i18n) => ({
 })
 
 export const MisoAbiByTemplateId = (chainId: ChainId, templateId: AuctionTemplate) => {
+  // @ts-ignore TYPE NEEDS FIXING
   return {
+    // @ts-ignore TYPE NEEDS FIXING
     1: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.Crowdsale.abi,
+    // @ts-ignore TYPE NEEDS FIXING
     2: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.DutchAuction.abi,
+    // @ts-ignore TYPE NEEDS FIXING
     3: MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.BatchAuction.abi,
   }[templateId]
 }
@@ -291,8 +299,10 @@ export const ISO_COUNTRIES = {
   ZW: 'Zimbabwe',
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function getCountryName(countryCode) {
   if (ISO_COUNTRIES.hasOwnProperty(countryCode)) {
+    // @ts-ignore TYPE NEEDS FIXING
     return ISO_COUNTRIES[countryCode]
   } else {
     return countryCode
@@ -301,7 +311,8 @@ export function getCountryName(countryCode) {
 
 export const getNativeOrToken = (chainId: ChainId, paymentCurrencyInfo: AuctionPaymentCurrencyInfo) => {
   return paymentCurrencyInfo.addr === NATIVE_PAYMENT_TOKEN
-    ? NATIVE[chainId]
+    ? // @ts-ignore TYPE NEEDS FIXING
+      NATIVE[chainId]
     : new Token(
         chainId,
         paymentCurrencyInfo.addr,

--- a/src/features/on-ramp/ramp/index.tsx
+++ b/src/features/on-ramp/ramp/index.tsx
@@ -21,14 +21,17 @@ export default function Buy() {
   const { account, chainId } = useActiveWeb3React()
   const { i18n } = useLingui()
   const onClick = useCallback(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     if (!(chainId in DEFAULT_NETWORK)) {
       return
     }
 
     const widget = new RampInstantSDK({
+      // @ts-ignore TYPE NEEDS FIXING
       userAddress: account,
       hostAppName: 'SUSHI',
       hostLogoUrl: 'http://sushiswap-interface-canary.vercel.app/_next/image?url=%2Flogo.png&w=32&q=75',
+      // @ts-ignore TYPE NEEDS FIXING
       defaultAsset: DEFAULT_CRYPTO_CURRENCY[chainId],
     })
 

--- a/src/features/on-ramp/transak/index.tsx
+++ b/src/features/on-ramp/transak/index.tsx
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import { ChainId } from '@sushiswap/core-sdk'
+// @ts-ignore TYPE NEEDS FIXING
 import transakSDK from '@transak/transak-sdk'
 import { useActiveWeb3React } from 'app/services/web3'
 import { useCallback } from 'react'
@@ -21,6 +22,7 @@ export default function Buy() {
   const { account, chainId } = useActiveWeb3React()
   const { i18n } = useLingui()
   useCallback(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     if (!(chainId in DEFAULT_NETWORK)) {
       return
     }
@@ -36,24 +38,29 @@ export default function Buy() {
       themeColor: '#0D0415',
       widgetHeight: '680px',
       widgetWidth: '100%',
+      // @ts-ignore TYPE NEEDS FIXING
       defaultNetwork: DEFAULT_NETWORK[chainId],
+      // @ts-ignore TYPE NEEDS FIXING
       defaultCryptoCurrency: DEFAULT_CRYPTO_CURRENCY[chainId],
     })
 
     transak.init()
 
     // To get all the events
+    // @ts-ignore TYPE NEEDS FIXING
     transak.on(transak.ALL_EVENTS, (data) => {
       console.log('ALL_EVENTS', data)
     })
 
     // This will trigger when the user closed the widget
+    // @ts-ignore TYPE NEEDS FIXING
     transak.on(transak.EVENTS.TRANSAK_WIDGET_CLOSE, (orderData) => {
       console.log('TRANSAK_WIDGET_CLOSE', orderData)
       transak.close()
     })
 
     // This will trigger when the user marks payment is made.
+    // @ts-ignore TYPE NEEDS FIXING
     transak.on(transak.EVENTS.TRANSAK_ORDER_SUCCESSFUL, (orderData) => {
       console.log('TRANSAK_ORDER_SUCCESSFUL', orderData)
       transak.close()

--- a/src/features/onsen/CurrencyInputPanel.tsx
+++ b/src/features/onsen/CurrencyInputPanel.tsx
@@ -76,8 +76,10 @@ export default function CurrencyInputPanel({
               )}
               <Input.Numeric
                 id="token-amount-input"
+                // @ts-ignore TYPE NEEDS FIXING
                 value={value}
                 onUserInput={(val) => {
+                  // @ts-ignore TYPE NEEDS FIXING
                   onUserInput(val)
                 }}
               />

--- a/src/features/onsen/FarmList.tsx
+++ b/src/features/onsen/FarmList.tsx
@@ -9,6 +9,7 @@ import InfiniteScroll from 'react-infinite-scroll-component'
 
 import FarmListItem from './FarmListItem'
 
+// @ts-ignore TYPE NEEDS FIXING
 const FarmList = ({ farms, term }) => {
   const { items, requestSort, sortConfig } = useSortableData(farms, { key: 'tvl', direction: 'descending' })
   const { i18n } = useLingui()

--- a/src/features/onsen/FarmListItem.tsx
+++ b/src/features/onsen/FarmListItem.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 import { PairType } from './enum'
 import FarmListItemDetails from './FarmListItemDetails'
 
+// @ts-ignore TYPE NEEDS FIXING
 const FarmListItem = ({ farm, ...rest }) => {
   const token0 = useCurrency(farm.pair.token0.id)
   const token1 = useCurrency(farm.pair.token1.id)
@@ -25,6 +26,7 @@ const FarmListItem = ({ farm, ...rest }) => {
           >
             <div className="grid grid-cols-4">
               <div className="flex col-span-2 pl-4 space-x-4 md:col-span-1">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <DoubleLogo currency0={token0} currency1={token1} size={40} />
                 <div className="flex flex-col justify-center">
                   <div>
@@ -44,6 +46,7 @@ const FarmListItem = ({ farm, ...rest }) => {
               <div className="flex flex-col justify-center pl-8 font-bold">{formatNumber(farm.tvl, true)}</div>
               <div className="flex-row items-center hidden pl-4 space-x-4 md:flex">
                 <div className="flex items-center space-x-2">
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {farm?.rewards?.map((reward, i) => (
                     <div key={i} className="flex items-center">
                       <CurrencyLogo currency={reward.currency} size="30px" className="rounded-md" />
@@ -51,6 +54,7 @@ const FarmListItem = ({ farm, ...rest }) => {
                   ))}
                 </div>
                 <div className="flex flex-col space-y-1">
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {farm?.rewards?.map((reward, i) => (
                     <div key={i} className="text-xs md:text-sm whitespace-nowrap">
                       {formatNumber(reward.rewardPerDay)} {reward.currency.symbol} / DAY

--- a/src/features/onsen/FarmListItemDetails.tsx
+++ b/src/features/onsen/FarmListItemDetails.tsx
@@ -15,12 +15,14 @@ import ManageBar from './ManageBar'
 import ManageKashiPair from './ManageKashiPair'
 import ManageSwapPair from './ManageSwapPair'
 
+// @ts-ignore TYPE NEEDS FIXING
 const FarmListItemDetails = ({ farm }) => {
   const { i18n } = useLingui()
 
   const { chainId } = useActiveWeb3React()
 
   const liquidityToken = new Token(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId,
     getAddress(farm.pair.id),
     farm.pair.type === PairType.KASHI ? Number(farm.pair.asset.decimals) : 18,

--- a/src/features/onsen/FarmMenu.tsx
+++ b/src/features/onsen/FarmMenu.tsx
@@ -4,6 +4,7 @@ import { useActiveWeb3React } from 'app/services/web3'
 import { useWalletModalToggle } from 'app/state/application/hooks'
 import React from 'react'
 
+// @ts-ignore TYPE NEEDS FIXING
 const Menu = ({ positionsLength }) => {
   const { account, chainId } = useActiveWeb3React()
   const toggleWalletModal = useWalletModalToggle()
@@ -75,6 +76,7 @@ const Menu = ({ positionsLength }) => {
         </NavLink>
       )}
 
+      {/*@ts-ignore TYPE NEEDS FIXING*/}
       {[ChainId.CELO].includes(chainId) && (
         <>
           <NavLink

--- a/src/features/onsen/InformationDisclosure.tsx
+++ b/src/features/onsen/InformationDisclosure.tsx
@@ -9,6 +9,7 @@ import NavLink from '../../components/NavLink'
 import Typography from '../../components/Typography'
 import { PairType } from './enum'
 
+// @ts-ignore TYPE NEEDS FIXING
 const InformationDisclosure = ({ farm }) => {
   const { i18n } = useLingui()
 

--- a/src/features/onsen/InvestmentDetails.tsx
+++ b/src/features/onsen/InvestmentDetails.tsx
@@ -19,6 +19,7 @@ import { usePendingSushi, useUserInfo } from './hooks'
 import useMasterChef from './useMasterChef'
 import usePendingReward from './usePendingReward'
 
+// @ts-ignore TYPE NEEDS FIXING
 const InvestmentDetails = ({ farm }) => {
   const { i18n } = useLingui()
 
@@ -38,6 +39,7 @@ const InvestmentDetails = ({ farm }) => {
   const token1 = useCurrency(farm.pair.token1.id)
 
   const liquidityToken = new Token(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId,
     getAddress(farm.pair.id),
     farm.pair.type === PairType.KASHI ? Number(farm.pair.asset.decimals) : 18,
@@ -52,9 +54,12 @@ const InvestmentDetails = ({ farm }) => {
     stakedAmount &&
     easyAmount(
       BigNumber.from(stakedAmount.quotient.toString()).mulDiv(
+        // @ts-ignore TYPE NEEDS FIXING
         kashiPair.currentAllAssets.value,
+        // @ts-ignore TYPE NEEDS FIXING
         kashiPair.totalAsset.base
       ),
+      // @ts-ignore TYPE NEEDS FIXING
       kashiPair.asset
     )
 
@@ -62,16 +67,21 @@ const InvestmentDetails = ({ farm }) => {
   const pendingReward = usePendingReward(farm)
 
   const positionFiatValue = CurrencyAmount.fromRawAmount(
+    // @ts-ignore TYPE NEEDS FIXING
     USD[chainId],
     farm.pair.type === PairType.KASHI
-      ? kashiAssetAmount?.usdValue.toString() ?? ZERO
+      ? // @ts-ignore TYPE NEEDS FIXING
+        kashiAssetAmount?.usdValue.toString() ?? ZERO
       : JSBI.BigInt(
           ((Number(stakedAmount?.toExact() ?? '0') * farm.pair.reserveUSD) / farm.pair.totalSupply)
+            // @ts-ignore TYPE NEEDS FIXING
             .toFixed(USD[chainId].decimals)
+            // @ts-ignore TYPE NEEDS FIXING
             .toBigNumber(USD[chainId].decimals)
         )
   )
 
+  // @ts-ignore TYPE NEEDS FIXING
   const secondaryRewardOnly = [ChainId.FUSE].includes(chainId)
 
   const rewardValue = !secondaryRewardOnly
@@ -106,9 +116,11 @@ const InvestmentDetails = ({ farm }) => {
         <div className="flex justify-between">
           <div className="flex flex-col justify-center space-y-2">
             <div className="flex items-center space-x-2">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <CurrencyLogo currency={token0} size="30px" />
               {farm.pair.type === PairType.KASHI && (
                 <Typography>
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {formatNumber(kashiAssetAmount?.value.toFixed(kashiPair.asset.tokenInfo.decimals) ?? 0)}
                 </Typography>
               )}
@@ -121,6 +133,7 @@ const InvestmentDetails = ({ farm }) => {
             </div>
             {farm.pair.type === PairType.SWAP && (
               <div className="flex items-center space-x-2">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <CurrencyLogo currency={token1} size="30px" />
                 <Typography>
                   {formatNumber((farm.pair.reserve1 * Number(stakedAmount?.toExact() ?? 0)) / farm.pair.totalSupply)}
@@ -148,6 +161,7 @@ const InvestmentDetails = ({ farm }) => {
         <div className="w-full bg-transparent border border-b-0 border-transparent rounded h-0font-bold text-high-emphesis border-gradient-r-blue-pink-dark-800 opacity-20" />
         <div className="flex justify-between">
           <div className="flex flex-col space-y-2">
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {farm?.rewards?.map((reward, i) => (
               <div key={i} className="flex items-center space-x-2">
                 <CurrencyLogo currency={reward.currency} size="30px" className="rounded-md" />

--- a/src/features/onsen/KashiDeposit.tsx
+++ b/src/features/onsen/KashiDeposit.tsx
@@ -19,6 +19,7 @@ import React, { useState } from 'react'
 
 import CurrencyInputPanel from './CurrencyInputPanel'
 
+// @ts-ignore TYPE NEEDS FIXING
 const KashiDeposit = ({ pair, useBento }) => {
   const { i18n } = useLingui()
   const { account, chainId } = useActiveWeb3React()
@@ -28,17 +29,20 @@ const KashiDeposit = ({ pair, useBento }) => {
   const [depositValue, setDepositValue] = useState('')
 
   const assetNative = WNATIVE[chainId || 1].address === pair?.asset.address
+  // @ts-ignore TYPE NEEDS FIXING
   const ethBalance = useETHBalances(assetNative ? [account] : [])
 
   const balanceAmount = useBento
     ? pair?.asset.bentoBalance
     : assetNative
-    ? BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
+    ? // @ts-ignore TYPE NEEDS FIXING
+      BigNumber.from(ethBalance[account]?.quotient.toString() || 0)
     : pair?.asset.balance
 
   const balance =
     assetToken &&
     balanceAmount &&
+    // @ts-ignore TYPE NEEDS FIXING
     CurrencyAmount.fromRawAmount(assetNative ? WNATIVE[chainId] : assetToken, balanceAmount)
 
   const maxAmount = balance
@@ -58,6 +62,7 @@ const KashiDeposit = ({ pair, useBento }) => {
     if (pair?.currentExchangeRate.isZero()) {
       cooker.updateExchangeRate(false, ZERO, ZERO)
     }
+    // @ts-ignore TYPE NEEDS FIXING
     cooker.addAsset(BigNumber.from(parsedDepositValue.quotient.toString()), useBento)
     return `${i18n._(t`Deposit`)} ${pair?.asset.tokenInfo.symbol}`
   }

--- a/src/features/onsen/KashiWithdraw.tsx
+++ b/src/features/onsen/KashiWithdraw.tsx
@@ -17,6 +17,7 @@ import React, { useState } from 'react'
 
 import CurrencyInputPanel from './CurrencyInputPanel'
 
+// @ts-ignore TYPE NEEDS FIXING
 const KashiWithdraw = ({ pair, useBento }) => {
   const { i18n } = useLingui()
   const { account } = useActiveWeb3React()
@@ -39,6 +40,7 @@ const KashiWithdraw = ({ pair, useBento }) => {
 
   async function onWithdraw(cooker: KashiCooker): Promise<string> {
     const maxFraction = minimum(pair.userAssetFraction, pair.maxAssetAvailableFraction)
+    // @ts-ignore TYPE NEEDS FIXING
     const fraction = BigNumber.from(parsedWithdrawValue.quotient.toString()).mulDiv(
       pair.currentTotalAsset.base,
       pair.currentAllAssets.value
@@ -68,6 +70,7 @@ const KashiWithdraw = ({ pair, useBento }) => {
           setWithdrawValue(maxAmount?.toExact() ?? '')
         }}
         onUserInput={(value) => setWithdrawValue(value)}
+        // @ts-ignore TYPE NEEDS FIXING
         currencyBalance={available}
         fiatValue={availableFiatValue}
       />

--- a/src/features/onsen/ManageBar.tsx
+++ b/src/features/onsen/ManageBar.tsx
@@ -32,6 +32,7 @@ import { Chef, PairType } from './enum'
 import { useUserInfo } from './hooks'
 import useMasterChef from './useMasterChef'
 
+// @ts-ignore TYPE NEEDS FIXING
 const ManageBar = ({ farm }) => {
   const { account, chainId } = useActiveWeb3React()
 
@@ -45,6 +46,7 @@ const ManageBar = ({ farm }) => {
   const addTransaction = useTransactionAdder()
 
   const liquidityToken = new Token(
+    // @ts-ignore TYPE NEEDS FIXING
     chainId,
     getAddress(farm.pair.id),
     farm.pair.type === PairType.KASHI ? Number(farm.pair.asset.decimals) : 18,
@@ -53,44 +55,57 @@ const ManageBar = ({ farm }) => {
 
   const kashiPair = useKashiPair(farm.pair.id)
 
+  // @ts-ignore TYPE NEEDS FIXING
   const balance = useCurrencyBalance(account, liquidityToken)
 
   const stakedAmount = useUserInfo(farm, liquidityToken)
 
   const balanceFiatValue = CurrencyAmount.fromRawAmount(
+    // @ts-ignore TYPE NEEDS FIXING
     USD[chainId],
     farm.pair.type === PairType.KASHI
       ? kashiPair && balance
         ? getUSDValue(
             BigNumber.from(balance.quotient.toString()).mulDiv(
+              // @ts-ignore TYPE NEEDS FIXING
               kashiPair.currentAllAssets.value,
+              // @ts-ignore TYPE NEEDS FIXING
               kashiPair.totalAsset.base
             ),
+            // @ts-ignore TYPE NEEDS FIXING
             kashiPair.asset
           ).toString()
         : ZERO
       : JSBI.BigInt(
           ((Number(balance?.toExact() ?? '0') * farm.pair.reserveUSD) / farm.pair.totalSupply)
+            // @ts-ignore TYPE NEEDS FIXING
             .toFixed(USD[chainId].decimals)
+            // @ts-ignore TYPE NEEDS FIXING
             .toBigNumber(USD[chainId].decimals)
         )
   )
 
   const stakedAmountFiatValue = CurrencyAmount.fromRawAmount(
+    // @ts-ignore TYPE NEEDS FIXING
     USD[chainId],
     farm.pair.type === PairType.KASHI
       ? kashiPair && stakedAmount
         ? getUSDValue(
             BigNumber.from(stakedAmount.quotient.toString()).mulDiv(
+              // @ts-ignore TYPE NEEDS FIXING
               kashiPair.currentAllAssets.value,
+              // @ts-ignore TYPE NEEDS FIXING
               kashiPair.totalAsset.base
             ),
+            // @ts-ignore TYPE NEEDS FIXING
             kashiPair.asset
           ).toString()
         : ZERO
       : JSBI.BigInt(
           ((Number(stakedAmount?.toExact() ?? '0') * farm.pair.reserveUSD) / farm.pair.totalSupply)
+            // @ts-ignore TYPE NEEDS FIXING
             .toFixed(USD[chainId].decimals)
+            // @ts-ignore TYPE NEEDS FIXING
             .toBigNumber(USD[chainId].decimals)
         )
   )
@@ -115,6 +130,7 @@ const ManageBar = ({ farm }) => {
     },
   }
 
+  // @ts-ignore TYPE NEEDS FIXING
   const [approvalState, approve] = useApproveCallback(parsedDepositValue, APPROVAL_ADDRESSES[farm.chef][chainId])
 
   const depositError = !parsedDepositValue
@@ -127,7 +143,8 @@ const ManageBar = ({ farm }) => {
 
   const withdrawError = !parsedWithdrawValue
     ? 'Enter an amount'
-    : stakedAmount.lessThan(parsedWithdrawValue)
+    : // @ts-ignore TYPE NEEDS FIXING
+    stakedAmount.lessThan(parsedWithdrawValue)
     ? 'Insufficient balance'
     : undefined
 
@@ -165,8 +182,10 @@ const ManageBar = ({ farm }) => {
               key={i}
               onClick={() => {
                 toggle
-                  ? setDepositValue(balance.multiply(multipler).divide(100).toExact())
-                  : setWithdrawValue(stakedAmount.multiply(multipler).divide(100).toExact())
+                  ? // @ts-ignore TYPE NEEDS FIXING
+                    setDepositValue(balance.multiply(multipler).divide(100).toExact())
+                  : // @ts-ignore TYPE NEEDS FIXING
+                    setWithdrawValue(stakedAmount.multiply(multipler).divide(100).toExact())
               }}
               className={classNames(
                 'text-md border border-opacity-50',
@@ -187,6 +206,7 @@ const ManageBar = ({ farm }) => {
             id="add-liquidity-input-tokenb"
             hideIcon
             onUserInput={(value) => setDepositValue(value)}
+            // @ts-ignore TYPE NEEDS FIXING
             currencyBalance={balance}
             fiatValue={balanceFiatValue}
             showMaxButton={false}
@@ -209,6 +229,7 @@ const ManageBar = ({ farm }) => {
               onClick={async () => {
                 try {
                   // KMP decimals depend on asset, SLP is always 18
+                  // @ts-ignore TYPE NEEDS FIXING
                   const tx = await deposit(farm.id, BigNumber.from(parsedDepositValue.quotient.toString()))
                   addTransaction(tx, {
                     summary: `Deposit ${farm.pair.token0.name}/${farm.pair.token1.name}`,
@@ -231,6 +252,7 @@ const ManageBar = ({ farm }) => {
             id="add-liquidity-input-tokenb"
             hideIcon
             onUserInput={(value) => setWithdrawValue(value)}
+            // @ts-ignore TYPE NEEDS FIXING
             currencyBalance={stakedAmount}
             fiatValue={stakedAmountFiatValue}
             showMaxButton={false}
@@ -244,6 +266,7 @@ const ManageBar = ({ farm }) => {
               onClick={async () => {
                 try {
                   // KMP decimals depend on asset, SLP is always 18
+                  // @ts-ignore TYPE NEEDS FIXING
                   const tx = await withdraw(farm.id, BigNumber.from(parsedWithdrawValue.quotient.toString()))
                   addTransaction(tx, {
                     summary: `Withdraw ${farm.pair.token0.name}/${farm.pair.token1.name}`,

--- a/src/features/onsen/ManageKashiPair.tsx
+++ b/src/features/onsen/ManageKashiPair.tsx
@@ -9,6 +9,7 @@ import { useKashiPair } from '../kashi/hooks'
 import KashiDeposit from './KashiDeposit'
 import KashiWithdraw from './KashiWithdraw'
 
+// @ts-ignore TYPE NEEDS FIXING
 const ManageKashiPair = ({ farm }) => {
   const { i18n } = useLingui()
 

--- a/src/features/onsen/ManageSwapPair.tsx
+++ b/src/features/onsen/ManageSwapPair.tsx
@@ -9,6 +9,7 @@ import React, { useState } from 'react'
 import PoolAddLiquidity from './PoolAddLiquidity'
 import PoolRemoveLiquidity from './PoolRemoveLiquidity'
 
+// @ts-ignore TYPE NEEDS FIXING
 const ManageSwapPair = ({ farm }) => {
   const [toggle, setToggle] = useState(true)
 

--- a/src/features/onsen/PoolAddLiquidity.tsx
+++ b/src/features/onsen/PoolAddLiquidity.tsx
@@ -27,13 +27,16 @@ import CurrencyInputPanel from './CurrencyInputPanel'
 
 const DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
 
+// @ts-ignore TYPE NEEDS FIXING
 const PoolDeposit = ({ currencyA, currencyB }) => {
   const { i18n } = useLingui()
   const { account, chainId, library } = useActiveWeb3React()
 
   const [useETH, setUseETH] = useState(chainId !== ChainId.CELO)
 
+  // @ts-ignore TYPE NEEDS FIXING
   chainId && useETH && currencyA && currencyEquals(currencyA, WNATIVE[chainId]) && (currencyA = NATIVE[chainId])
+  // @ts-ignore TYPE NEEDS FIXING
   chainId && useETH && currencyB && currencyEquals(currencyB, WNATIVE[chainId]) && (currencyB = NATIVE[chainId])
 
   const oneCurrencyIsETH = currencyA?.isNative || currencyB?.isNative
@@ -281,6 +284,7 @@ const PoolDeposit = ({ currencyA, currencyB }) => {
           onMax={() => {
             onFieldAInput(maxAmounts[Field.CURRENCY_A]?.toExact() ?? '')
           }}
+          // @ts-ignore TYPE NEEDS FIXING
           currencyBalance={currencyBalances[Field.CURRENCY_A]}
           fiatValue={currencyAFiatValue}
         />
@@ -294,6 +298,7 @@ const PoolDeposit = ({ currencyA, currencyB }) => {
             onMax={() => {
               onFieldBInput(maxAmounts[Field.CURRENCY_B]?.toExact() ?? '')
             }}
+            // @ts-ignore TYPE NEEDS FIXING
             currencyBalance={currencyBalances[Field.CURRENCY_B]}
             fiatValue={currencyBFiatValue}
           />
@@ -303,6 +308,7 @@ const PoolDeposit = ({ currencyA, currencyB }) => {
               onClick={() => setUseETH(!useETH)}
             >
               {i18n._(t`Use`)} {useETH && 'W'}
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {NATIVE[chainId].symbol}
             </a>
           )}

--- a/src/features/onsen/PoolRemoveLiquidity.tsx
+++ b/src/features/onsen/PoolRemoveLiquidity.tsx
@@ -31,12 +31,15 @@ import ReactGA from 'react-ga'
 
 const DEFAULT_REMOVE_LIQUIDITY_SLIPPAGE_TOLERANCE = new Percent(5, 100)
 
+// @ts-ignore TYPE NEEDS FIXING
 const PoolWithdraw = ({ currencyA, currencyB }) => {
   const { i18n } = useLingui()
   const { account, chainId, library } = useActiveWeb3React()
 
   const [useETH, setUseETH] = useState(false)
+  // @ts-ignore TYPE NEEDS FIXING
   useETH && currencyA && currencyEquals(currencyA, WNATIVE[chainId]) && (currencyA = NATIVE[chainId])
+  // @ts-ignore TYPE NEEDS FIXING
   useETH && currencyB && currencyEquals(currencyB, WNATIVE[chainId]) && (currencyB = NATIVE[chainId])
 
   const [tokenA, tokenB] = useMemo(() => [currencyA?.wrapped, currencyB?.wrapped], [currencyA, currencyB])
@@ -102,6 +105,7 @@ const PoolWithdraw = ({ currencyA, currencyB }) => {
         await gatherPermitSignature()
       } catch (error) {
         // try to approve if gatherPermitSignature failed for any reason other than the user rejecting it
+        // @ts-ignore TYPE NEEDS FIXING
         if (error?.code !== 4001) {
           await approveCallback()
         }
@@ -450,6 +454,7 @@ const PoolWithdraw = ({ currencyA, currencyB }) => {
                 onClick={() => setUseETH(!useETH)}
               >
                 {i18n._(t`Receive`)} {useETH && 'W'}
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {NATIVE[chainId].symbol}
               </a>
             )}

--- a/src/features/onsen/hooks.ts
+++ b/src/features/onsen/hooks.ts
@@ -59,6 +59,7 @@ export function useChefContracts(chefs: Chef[]) {
   return chefs.map((chef) => contracts[chef])
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useUserInfo(farm, token) {
   const { account } = useActiveWeb3React()
 
@@ -80,6 +81,7 @@ export function useUserInfo(farm, token) {
   return amount ? CurrencyAmount.fromRawAmount(token, amount) : undefined
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function usePendingSushi(farm) {
   const { account, chainId } = useActiveWeb3React()
 
@@ -98,9 +100,11 @@ export function usePendingSushi(farm) {
 
   const amount = value ? JSBI.BigInt(value.toString()) : undefined
 
+  // @ts-ignore TYPE NEEDS FIXING
   return amount ? CurrencyAmount.fromRawAmount(SUSHI[chainId], amount) : undefined
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function usePendingToken(farm, contract) {
   const { account } = useActiveWeb3React()
 
@@ -114,6 +118,7 @@ export function usePendingToken(farm, contract) {
   const pendingTokens = useSingleContractMultipleData(
     args ? contract : null,
     'pendingTokens',
+    // @ts-ignore TYPE NEEDS FIXING
     args.map((arg) => [...arg, '0'])
   )
 
@@ -133,8 +138,10 @@ export function useChefPositions(contract?: Contract | null, rewarder?: Contract
     return [...Array(numberOfPools.toNumber()).keys()].map((pid) => [String(pid), String(account)])
   }, [numberOfPools, account])
 
+  // @ts-ignore TYPE NEEDS FIXING
   const pendingSushi = useSingleContractMultipleData(args ? contract : null, 'pendingSushi', args)
 
+  // @ts-ignore TYPE NEEDS FIXING
   const userInfo = useSingleContractMultipleData(args ? contract : null, 'userInfo', args)
 
   // const pendingTokens = useSingleContractMultipleData(
@@ -144,12 +151,16 @@ export function useChefPositions(contract?: Contract | null, rewarder?: Contract
   // )
 
   const getChef = useCallback(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     if (MASTERCHEF_ADDRESS[chainId] === contract.address) {
       return Chef.MASTERCHEF
+      // @ts-ignore TYPE NEEDS FIXING
     } else if (MASTERCHEF_V2_ADDRESS[chainId] === contract.address) {
       return Chef.MASTERCHEF_V2
+      // @ts-ignore TYPE NEEDS FIXING
     } else if (MINICHEF_ADDRESS[chainId] === contract.address) {
       return Chef.MINICHEF
+      // @ts-ignore TYPE NEEDS FIXING
     } else if (OLD_FARMS[chainId] === contract.address) {
       return Chef.OLD_FARMS
     }
@@ -161,8 +172,11 @@ export function useChefPositions(contract?: Contract | null, rewarder?: Contract
     }
     return zip(pendingSushi, userInfo)
       .map((data, i) => ({
+        // @ts-ignore TYPE NEEDS FIXING
         id: args[i][0],
+        // @ts-ignore TYPE NEEDS FIXING
         pendingSushi: data[0].result?.[0] || Zero,
+        // @ts-ignore TYPE NEEDS FIXING
         amount: data[1].result?.[0] || Zero,
         chef: getChef(),
         // pendingTokens: data?.[2]?.result,

--- a/src/features/onsen/usePendingReward.ts
+++ b/src/features/onsen/usePendingReward.ts
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { Chef } from './enum'
 
+// @ts-ignore TYPE NEEDS FIXING
 const usePending = (farm) => {
   const [balance, setBalance] = useState<string>('0')
 
@@ -35,6 +36,7 @@ const usePending = (farm) => {
   useEffect(() => {
     async function fetchPendingReward() {
       try {
+        // @ts-ignore TYPE NEEDS FIXING
         const pending = await contract[chainId]?.pendingTokens(farm.id, account, '0')
         // console.log({ farm })
         // todo: do not assume [0] or that rewardToken has 18 decimals (only works w/ mastechefv2 currently)

--- a/src/features/trade/Header.tsx
+++ b/src/features/trade/Header.tsx
@@ -10,6 +10,7 @@ import { useActiveWeb3React } from 'app/services/web3'
 import { useRouter } from 'next/router'
 import React, { FC, useState } from 'react'
 
+// @ts-ignore TYPE NEEDS FIXING
 const getQuery = (input, output) => {
   if (!input && !output) return
 

--- a/src/features/transactions/Transactions.tsx
+++ b/src/features/transactions/Transactions.tsx
@@ -12,6 +12,7 @@ import {
 import { useLegacyTransactions } from 'app/services/graph/hooks/transactions/legacy'
 import { useTridentTransactions } from 'app/services/graph/hooks/transactions/trident'
 import React, { FC } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import { useFlexLayout, usePagination, useSortBy, useTable } from 'react-table'
 
 import Typography from '../../components/Typography'
@@ -88,6 +89,7 @@ const _Transactions: FC<TransactionFetcherState> = ({ transactions, error, loadi
               prepareRow(row)
               return (
                 <tr {...row.getRowProps()} key={i} className={TABLE_TBODY_TR_CLASSNAME}>
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {row.cells.map((cell, i) => {
                     return (
                       <td key={i} {...cell.getCellProps()} className={TABLE_TBODY_TD_CLASSNAME(i, row.cells.length)}>

--- a/src/features/transactions/useTableConfig.tsx
+++ b/src/features/transactions/useTableConfig.tsx
@@ -28,6 +28,7 @@ export const useTableConfig = (transactions?: Transactions[]) => {
       {
         Header: 'To',
         accessor: 'address',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => {
           return (
             <ExternalLink color="blue" href={`https://etherscan.io/address/${props.cell.value}`}>

--- a/src/features/trident/PoolContext.tsx
+++ b/src/features/trident/PoolContext.tsx
@@ -68,10 +68,12 @@ const PoolContext: FC = ({ children }) => {
       // Convert from shares to amount
       return [
         toAmountCurrencyAmount(
+          // @ts-ignore TYPE NEEDS FIXING
           rebases[poolWithState.pool.token0.wrapped.address],
           poolWithState.pool.getLiquidityValue(poolWithState.pool.token0, totalSupply.wrapped, poolBalance.wrapped)
         ),
         toAmountCurrencyAmount(
+          // @ts-ignore TYPE NEEDS FIXING
           rebases[poolWithState.pool.token1.wrapped.address],
           poolWithState.pool.getLiquidityValue(poolWithState.pool.token1, totalSupply.wrapped, poolBalance.wrapped)
         ),
@@ -83,6 +85,7 @@ const PoolContext: FC = ({ children }) => {
 
   return (
     <Context.Provider
+      // @ts-ignore TYPE NEEDS FIXING
       value={useMemo(
         () => ({
           poolWithState,

--- a/src/features/trident/SumUSDCValues.tsx
+++ b/src/features/trident/SumUSDCValues.tsx
@@ -6,6 +6,7 @@ import { FC, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 // Dummy component that fetches usdcValue
 const USDCValue: FC<{
   amount?: CurrencyAmount<Currency>
+  // @ts-ignore TYPE NEEDS FIXING
   update(address: string, value?: CurrencyAmount<Currency>)
 }> = ({ amount, update }) => {
   const usdcValue = useUSDCValue(amount)
@@ -14,6 +15,7 @@ const USDCValue: FC<{
   useEffect(() => {
     if (!address) return
 
+    // @ts-ignore TYPE NEEDS FIXING
     update(address, usdcValue)
     return () => {
       update(address, undefined)

--- a/src/features/trident/TransactionDetailsExplanationModal.tsx
+++ b/src/features/trident/TransactionDetailsExplanationModal.tsx
@@ -9,6 +9,7 @@ const TransactionDetailsExplanationModal: FC = ({ children }) => {
 
   return (
     <HeadlessUiModal trigger={children}>
+      {/*@ts-ignore TYPE NEEDS FIXING*/}
       {({ setOpen }) => (
         <div className="flex flex-col gap-4 lg:max-w-2xl">
           <HeadlessUiModal.Header header={i18n._(t`Transaction Details`)} onClose={() => setOpen(false)} />

--- a/src/features/trident/TridentApproveGate.tsx
+++ b/src/features/trident/TridentApproveGate.tsx
@@ -54,12 +54,14 @@ const TokenApproveButton: FC<TokenApproveButtonProps> = memo(
     useEffect(() => {
       if (!inputAmount?.currency.wrapped.address) return
 
+      // @ts-ignore TYPE NEEDS FIXING
       onStateChange((prevState) => ({
         ...prevState,
         [inputAmount.currency.wrapped.address]: signatureData ? ApprovalState.APPROVED : approveState,
       }))
 
       return () =>
+        // @ts-ignore TYPE NEEDS FIXING
         onStateChange((prevState) => {
           const state = { ...prevState }
           if (state[inputAmount!!.currency.wrapped.address]) {

--- a/src/features/trident/add/BentoBoxFundingSourceModal.tsx
+++ b/src/features/trident/add/BentoBoxFundingSourceModal.tsx
@@ -21,6 +21,7 @@ const BentoBoxFundingSourceModal: FC = () => {
         </div>
       }
     >
+      {/*@ts-ignore TYPE NEEDS FIXING*/}
       {({ setOpen }) => (
         <div className="flex flex-col gap-4">
           <HeadlessUiModal.Header header={i18n._(t`Bentobox`)} onClose={() => setOpen(false)} />

--- a/src/features/trident/add/useAddLiquidityDerivedState.ts
+++ b/src/features/trident/add/useAddLiquidityDerivedState.ts
@@ -67,6 +67,7 @@ export const useAddLiquidityDerivedInput = () => {
 
   // Similar to setState(prevState => newState) if a function is passed as value to setInputs, pass previous state
   const setInputs = useMemo(
+    // @ts-ignore TYPE NEEDS FIXING
     () => (values) => dispatch(setAddNormalInput(typeof values === 'function' ? values(normalInput) : values)),
     [dispatch, normalInput]
   )

--- a/src/features/trident/add/useAddLiquidityExecute.ts
+++ b/src/features/trident/add/useAddLiquidityExecute.ts
@@ -120,6 +120,7 @@ export const useAddLiquidityExecute: UseAddLiquidityExecute = () => {
       } catch (error) {
         dispatch(setAddAttemptingTxn(false))
         // we only care if the error is something _other_ than the user rejected the tx
+        // @ts-ignore TYPE NEEDS FIXING
         if (error?.code !== 4001) {
           console.error(error)
         }

--- a/src/features/trident/balances/AssetBalances/AssetBalances.tsx
+++ b/src/features/trident/balances/AssetBalances/AssetBalances.tsx
@@ -10,6 +10,7 @@ import {
   TABLE_WRAPPER_DIV_CLASSNAME,
 } from 'app/features/trident/constants'
 import React, { FC } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import { useFlexLayout, usePagination, useSortBy, useTable } from 'react-table'
 
 interface AssetBalancesProps {
@@ -69,6 +70,7 @@ const AssetBalances: FC<AssetBalancesProps> = ({ config, loading, error, onSelec
                   onClick={() => onSelect && onSelect(row)}
                   className={TABLE_TBODY_TR_CLASSNAME}
                 >
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {row.cells.map((cell, i) => {
                     return (
                       <td key={i} {...cell.getCellProps()} className={TABLE_TBODY_TD_CLASSNAME(i, row.cells.length)}>

--- a/src/features/trident/balances/AssetBalances/index.tsx
+++ b/src/features/trident/balances/AssetBalances/index.tsx
@@ -70,6 +70,7 @@ export const WalletBalances = () => {
   const selected = useBalancesSelectedCurrency()
 
   const _balances = useAllTokenBalances()
+  // @ts-ignore TYPE NEEDS FIXING
   const ethBalance = useCurrencyBalance(account ? account : undefined, chainId ? NATIVE[chainId] : undefined)
 
   const balances = useMemo(() => {

--- a/src/features/trident/balances/AssetBalances/useLPTableConfig.tsx
+++ b/src/features/trident/balances/AssetBalances/useLPTableConfig.tsx
@@ -23,6 +23,7 @@ export const useLPTableConfig = (positions?: TridentPositionRow[]) => {
               Header: 'Assets',
               accessor: 'assets',
               className: 'text-left',
+              // @ts-ignore TYPE NEEDS FIXING
               Cell: ({ value, row: { original } }) => {
                 return <PoolCell assets={value} twapEnabled={original.twapEnabled} />
               },
@@ -36,7 +37,9 @@ export const useLPTableConfig = (positions?: TridentPositionRow[]) => {
               Cell: (props: { value: PoolType }) => {
                 return <Chip label={poolTypeNameMapper[props.value]} color={chipPoolColorMapper[props.value]} />
               },
+              // @ts-ignore TYPE NEEDS FIXING
               filter: (rows, id, filterValue) =>
+                // @ts-ignore TYPE NEEDS FIXING
                 rows.filter((row) => !filterValue.length || filterValue.includes(row.values.type)),
             },
             {
@@ -44,6 +47,7 @@ export const useLPTableConfig = (positions?: TridentPositionRow[]) => {
               accessor: 'swapFeePercent',
               maxWidth: 100,
               className: 'text-left hidden lg:flex',
+              // @ts-ignore TYPE NEEDS FIXING
               Cell: (props) => <span>{props.value}%</span>,
               filter: feeTiersFilter,
             },
@@ -53,6 +57,7 @@ export const useLPTableConfig = (positions?: TridentPositionRow[]) => {
               accessor: 'value',
               maxWidth: 100,
               className: 'text-right flex justify-end',
+              // @ts-ignore TYPE NEEDS FIXING
               Cell: (props) => {
                 return (
                   <Typography weight={700} className="text-high-emphesis text-right w-full">
@@ -66,6 +71,7 @@ export const useLPTableConfig = (positions?: TridentPositionRow[]) => {
               accessor: 'apy',
               maxWidth: 100,
               className: 'text-right flex justify-end',
+              // @ts-ignore TYPE NEEDS FIXING
               Cell: ({ row }) => {
                 const { data: stats } = useRollingPoolStats({
                   chainId,
@@ -87,12 +93,14 @@ export const useLPTableConfig = (positions?: TridentPositionRow[]) => {
               maxWidth: 100,
               className: 'text-right flex justify-end',
               cellClassName: 'justify-end',
+              // @ts-ignore TYPE NEEDS FIXING
               Cell: ({ row: { original } }) => {
                 return (
                   <Link
                     href={{
                       pathname: `/trident/pool`,
                       query: {
+                        // @ts-ignore TYPE NEEDS FIXING
                         tokens: original.assets.map((el) => el.address),
                         fee: original.swapFeePercent * 100,
                         twap: original.twapEnabled,

--- a/src/features/trident/balances/AssetBalances/useTableConfig.tsx
+++ b/src/features/trident/balances/AssetBalances/useTableConfig.tsx
@@ -15,6 +15,7 @@ export const useTableConfig = (assets?: Assets[]) => {
         accessor: 'asset',
         minWidth: 100,
         className: 'text-left',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => {
           return (
             <div className="flex gap-2.5 items-center">
@@ -36,6 +37,7 @@ export const useTableConfig = (assets?: Assets[]) => {
         accessor: 'asset',
         maxWidth: 100,
         className: 'text-left',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => {
           return (
             <Typography
@@ -55,6 +57,7 @@ export const useTableConfig = (assets?: Assets[]) => {
         accessor: 'asset',
         maxWidth: 100,
         className: 'text-right flex justify-end',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => {
           const usdcValue = useUSDCValue(props.cell.value)
           return (

--- a/src/features/trident/balances/BalancesSum.tsx
+++ b/src/features/trident/balances/BalancesSum.tsx
@@ -47,6 +47,7 @@ export const BentoBalancesSum = () => {
 export const WalletBalancesSum = () => {
   const { chainId, account } = useActiveWeb3React()
   const tokenBalances = useAllTokenBalances()
+  // @ts-ignore TYPE NEEDS FIXING
   const ethBalance = useCurrencyBalance(account ? account : undefined, chainId ? NATIVE[chainId] : undefined)
   const amounts = useMemo(() => {
     const res: CurrencyAmount<Currency>[] = Object.values(tokenBalances).filter((cur) => cur.greaterThan(ZERO))

--- a/src/features/trident/balances/BentoActions.tsx
+++ b/src/features/trident/balances/BentoActions.tsx
@@ -23,6 +23,7 @@ const BentoActions: FC = () => {
 
   const swapActionHandler = useCallback(async () => {
     if (currency?.isNative) return router.push('/trident/swap')
+    // @ts-ignore TYPE NEEDS FIXING
     return router.push(`/trident/swap?tokens=${NATIVE[chainId || 1].symbol}&tokens=${currency?.wrapped.address}`)
   }, [chainId, currency?.isNative, currency?.wrapped.address, router])
 

--- a/src/features/trident/balances/WalletActions.tsx
+++ b/src/features/trident/balances/WalletActions.tsx
@@ -23,8 +23,10 @@ const WalletActions: FC = () => {
   const router = useRouter()
 
   const swapActionHandler = useCallback(async () => {
+    // @ts-ignore TYPE NEEDS FIXING
     if (featureEnabled(Feature.TRIDENT, chainId)) {
       if (currency?.isNative) return router.push('/trident/swap')
+      // @ts-ignore TYPE NEEDS FIXING
       return router.push(`/trident/swap?&tokens=${NATIVE[chainId].symbol}&tokens=${currency?.wrapped.address}`)
     }
 
@@ -40,6 +42,7 @@ const WalletActions: FC = () => {
           {i18n._(t`Available Actions`)}
         </Typography>
         <ActionItem svg={<SwitchHorizontalIcon width={24} />} label={i18n._(t`Swap`)} onClick={swapActionHandler} />
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {featureEnabled(Feature.BENTOBOX, chainId) && (
           <>
             <ActionItem

--- a/src/features/trident/constants.ts
+++ b/src/features/trident/constants.ts
@@ -76,9 +76,11 @@ export const POOL_TYPES: PoolTypesInterface = {
 export const TABLE_WRAPPER_DIV_CLASSNAME =
   'overflow-x-auto border border-dark-900 rounded shadow-md bg-[rgba(0,0,0,0.12)]'
 export const TABLE_TABLE_CLASSNAME = 'w-full'
+// @ts-ignore TYPE NEEDS FIXING
 export const TABLE_TR_TH_CLASSNAME = (i, length) =>
   classNames('text-secondary text-sm py-3', i === 0 ? 'pl-4 text-left' : 'text-right', i === length - 1 ? 'pr-4' : '')
 export const TABLE_TBODY_TR_CLASSNAME = 'hover:bg-dark-900/40 hover:cursor-pointer'
+// @ts-ignore TYPE NEEDS FIXING
 export const TABLE_TBODY_TD_CLASSNAME = (i, length) =>
   classNames(
     'py-3 border-t border-dark-900 flex items-center',

--- a/src/features/trident/create/SelectedAsset.ts
+++ b/src/features/trident/create/SelectedAsset.ts
@@ -1,5 +1,6 @@
 import { Currency, CurrencyAmount } from '@sushiswap/core-sdk'
 import { tryParseAmount } from 'app/functions'
+// @ts-ignore TYPE NEEDS FIXING
 import uuidv4 from 'uuid/v4'
 
 export enum SpendSource {

--- a/src/features/trident/pool/PoolStats.tsx
+++ b/src/features/trident/pool/PoolStats.tsx
@@ -56,13 +56,16 @@ const PoolStats: FC<PoolStatsProps> = () => {
           </Typography>
           <div className="flex flex-row gap-2 lg:flex-col lg:gap-0">
             <Typography weight={700} variant={isDesktop ? 'lg' : 'base'} className="text-high-emphesis">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {stats?.[0]?.[value]}
             </Typography>
             <Typography
               weight={400}
               variant={isDesktop ? 'xs' : 'sm'}
+              // @ts-ignore TYPE NEEDS FIXING
               className={stats?.[0]?.[change] > 0 ? 'text-green' : 'text-red'}
             >
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {formatPercent(stats?.[0]?.[change])}
             </Typography>
           </div>

--- a/src/features/trident/pool/PoolStatsChart.tsx
+++ b/src/features/trident/pool/PoolStatsChart.tsx
@@ -59,25 +59,31 @@ const PoolStatsChart = () => {
 
   const graphData = useMemo(() => {
     const currentDate = Math.round(Date.now() / 1000)
-    return data
-      ?.reduce((acc, cur) => {
-        const x = cur.date.getTime()
-        if (Math.round(x / 1000) >= currentDate - chartTimespans[chartRange]) {
-          acc.push({
-            x,
-            y: Number(chartType === ChartType.Volume ? cur.volumeUSD : cur.liquidityUSD),
-          })
-        }
+    return (
+      data
+        ?.reduce((acc, cur) => {
+          const x = cur.date.getTime()
+          if (Math.round(x / 1000) >= currentDate - chartTimespans[chartRange]) {
+            acc.push({
+              // @ts-ignore TYPE NEEDS FIXING
+              x,
+              // @ts-ignore TYPE NEEDS FIXING
+              y: Number(chartType === ChartType.Volume ? cur.volumeUSD : cur.liquidityUSD),
+            })
+          }
 
-        return acc
-      }, [])
-      .sort((a, b) => a.x - b.x)
+          return acc
+        }, [])
+        // @ts-ignore TYPE NEEDS FIXING
+        .sort((a, b) => a.x - b.x)
+    )
   }, [data, chartRange, chartType])
 
   const [selectedIndex, setSelectedIndex] = useState(graphData?.length - 1)
 
   const chartButtons = (
     <div className="flex justify-between lg:justify-end lg:gap-1">
+      {/*@ts-ignore TYPE NEEDS FIXING*/}
       {Object.keys(chartTimespans).map((text: ChartRange) => (
         <Button
           key={text}
@@ -104,9 +110,11 @@ const PoolStatsChart = () => {
         <div className="w-full h-40 lg:order-2">
           <div className="mt-6">
             <Typography variant="h3" className="text-high-emphesis" weight={700}>
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {formatNumber(graphData[selectedIndex]?.y, true, false, 2)}
             </Typography>
             <Typography variant="sm" className="text-gray-500 text-high-emphesis" weight={700}>
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {formatDate(new Date(graphData[selectedIndex]?.x))}
             </Typography>
           </div>

--- a/src/features/trident/pool/Rewards.tsx
+++ b/src/features/trident/pool/Rewards.tsx
@@ -15,6 +15,7 @@ const Rewards: FC = () => {
   const { i18n } = useLingui()
 
   // TODO ramin:
+  // @ts-ignore TYPE NEEDS FIXING
   const rewardCurrency = SUSHI[chainId]
 
   return (

--- a/src/features/trident/pools/SearchResultPools.tsx
+++ b/src/features/trident/pools/SearchResultPools.tsx
@@ -12,6 +12,7 @@ import {
 import { PoolSortOption } from 'app/features/trident/pools/poolsSlice'
 import Link from 'next/link'
 import React, { FC } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import { useFilters, useFlexLayout, usePagination, useSortBy, useTable } from 'react-table'
 
 import { SearchCategoryLabel } from './SearchCategoryLabel'
@@ -81,6 +82,7 @@ const SearchResultPools: FC = () => {
                   href={{
                     pathname: `/trident/pool`,
                     query: {
+                      // @ts-ignore TYPE NEEDS FIXING
                       tokens: row.original.assets.map((asset) => asset.address),
                       fee: row.original.swapFee,
                       twap: row.original.twapEnabled,
@@ -90,6 +92,7 @@ const SearchResultPools: FC = () => {
                   passHref
                 >
                   <tr {...row.getRowProps()} className={TABLE_TBODY_TR_CLASSNAME}>
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     {row.cells.map((cell, i) => {
                       return (
                         <td key={i} {...cell.getCellProps()} className={TABLE_TBODY_TD_CLASSNAME(i, row.cells.length)}>

--- a/src/features/trident/pools/useInstantiateTableFeatures.tsx
+++ b/src/features/trident/pools/useInstantiateTableFeatures.tsx
@@ -10,6 +10,7 @@ const useInstantiateFilters = (setFilter: TableInstance['setFilter']) => {
   useMemo(() => setFilter('swapFee', { feeTiersSelected }), [feeTiersSelected, setFilter])
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const useInstantiateSorting = (toggleSortBy) => {
   const { sort } = useAppSelector(selectTridentPools)
 

--- a/src/features/trident/pools/usePoolsTableData.tsx
+++ b/src/features/trident/pools/usePoolsTableData.tsx
@@ -29,6 +29,7 @@ export const usePoolsTableData = () => {
       {
         Header: 'Assets',
         accessor: 'assets',
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: ({ value, row: { original } }) => {
           return <PoolCell assets={value} twapEnabled={original.twapEnabled} />
         },
@@ -41,13 +42,16 @@ export const usePoolsTableData = () => {
         Cell: (props: { value: PoolType }) => (
           <Chip label={poolTypeNameMapper[props.value]} color={chipPoolColorMapper[props.value]} />
         ),
+        // @ts-ignore TYPE NEEDS FIXING
         filter: (rows, id, filterValue) =>
+          // @ts-ignore TYPE NEEDS FIXING
           rows.filter((row) => !filterValue.length || filterValue.includes(row.values.type)),
       },
       {
         Header: 'Fee Tier',
         accessor: 'swapFee',
         maxWidth: 100,
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => <span>{props.value / 100}%</span>,
         filter: feeTiersFilter,
       },
@@ -55,12 +59,14 @@ export const usePoolsTableData = () => {
         Header: 'TVL',
         accessor: 'liquidityUSD',
         maxWidth: 100,
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: (props) => <span>{formatNumber(props.value, true)}</span>,
       },
       {
         Header: 'APY',
         accessor: 'apy',
         maxWidth: 100,
+        // @ts-ignore TYPE NEEDS FIXING
         Cell: ({ row }) => {
           const { data: stats } = useRollingPoolStats({
             chainId,

--- a/src/features/trident/remove/ClassicSingleAside.tsx
+++ b/src/features/trident/remove/ClassicSingleAside.tsx
@@ -77,6 +77,7 @@ const ClassicSingleAside = () => {
           dismissable={false}
           type="error"
           message={i18n._(
+            // @ts-ignore TYPE NEEDS FIXING
             t`Native ${NATIVE[chainId || 1].symbol} can't be withdrawn to BentoBox, ${
               WNATIVE[chainId || 1].symbol
             } will be received instead`

--- a/src/features/trident/remove/ClassicSingleMode.tsx
+++ b/src/features/trident/remove/ClassicSingleMode.tsx
@@ -63,6 +63,7 @@ const ClassicSingleMode: FC = () => {
     poolWithState?.pool?.token0.address === WNATIVE[chainId || 1].address ||
     poolWithState?.pool?.token1.address === WNATIVE[chainId || 1].address
   const assetSelectCurrencies = [poolWithState?.pool?.token0, poolWithState?.pool?.token1]
+  // @ts-ignore TYPE NEEDS FIXING
   if (oneTokenIsWETH) assetSelectCurrencies.push(NATIVE[chainId || 1])
 
   return (

--- a/src/features/trident/remove/ClassicStandardAside.tsx
+++ b/src/features/trident/remove/ClassicStandardAside.tsx
@@ -71,6 +71,7 @@ const ClassicStandardAside = () => {
           dismissable={false}
           type="error"
           message={i18n._(
+            // @ts-ignore TYPE NEEDS FIXING
             t`Native ${NATIVE[chainId || 1].symbol} can't be withdrawn to BentoBox, ${
               WNATIVE[chainId || 1].symbol
             } will be received instead`
@@ -86,6 +87,7 @@ const ClassicStandardAside = () => {
             <div className="flex gap-1.5 items-center">
               <CurrencyLogo currency={el?.currency} size={20} />
               <Typography
+                // @ts-ignore TYPE NEEDS FIXING
                 id={el?.currency.symbol.toLowerCase() + `-min-liquidity-output`}
                 variant="sm"
                 weight={700}
@@ -95,7 +97,8 @@ const ClassicStandardAside = () => {
               </Typography>
               <Typography variant="sm" weight={700} className="text-high-emphesis">
                 {el?.currency.wrapped.address === WNATIVE[chainId || 1].address && receiveNative && outputToWallet
-                  ? NATIVE[chainId || 1].symbol
+                  ? // @ts-ignore TYPE NEEDS FIXING
+                    NATIVE[chainId || 1].symbol
                   : el?.currency.symbol}
               </Typography>
             </div>

--- a/src/features/trident/remove/RemoveTransactionReviewStandardModal.tsx
+++ b/src/features/trident/remove/RemoveTransactionReviewStandardModal.tsx
@@ -29,6 +29,7 @@ const RemoveTransactionReviewStandardModal: FC<RemoveTransactionReviewStandardMo
 
   const liquidityOutput = minLiquidityOutput.map((el) => {
     if (el?.currency.wrapped.address === WNATIVE[chainId || 1].address && receiveETH) {
+      // @ts-ignore TYPE NEEDS FIXING
       return CurrencyAmount.fromRawAmount(NATIVE[chainId || 1], el.quotient.toString())
     }
 

--- a/src/features/trident/remove/useRemoveLiquidityExecute.ts
+++ b/src/features/trident/remove/useRemoveLiquidityExecute.ts
@@ -63,6 +63,7 @@ export const useRemoveLiquidityExecute = () => {
       ]
 
       const indexOfWETH = minOutputA.wrapped.currency.address === WNATIVE[chainId].address ? 0 : 1
+      // @ts-ignore TYPE NEEDS FIXING
       const receiveETH = receiveNative[0] && outputToWallet
       const actions = [
         approveMasterContractAction({ router, signature: bentoPermit }),
@@ -126,6 +127,7 @@ export const useRemoveLiquidityExecute = () => {
       } catch (error) {
         dispatch(setRemoveAttemptingTxn(false))
         // we only care if the error is something _other_ than the user rejected the tx
+        // @ts-ignore TYPE NEEDS FIXING
         if (error?.code !== 4001) {
           console.error(error)
         }

--- a/src/features/trident/remove/useRemoveLiquiditySingleExecute.ts
+++ b/src/features/trident/remove/useRemoveLiquiditySingleExecute.ts
@@ -104,6 +104,7 @@ export const useRemoveLiquiditySingleExecute = () => {
       } catch (error) {
         dispatch(setRemoveAttemptingTxn(false))
         // we only care if the error is something _other_ than the user rejected the tx
+        // @ts-ignore TYPE NEEDS FIXING
         if (error?.code !== 4001) {
           console.error(error)
         }

--- a/src/features/trident/remove/useRemoveLiquidityState.ts
+++ b/src/features/trident/remove/useRemoveLiquidityState.ts
@@ -11,6 +11,7 @@ export const useAddLiquidityState = () => {
 
   // Similar to setState(prevState => newState) if a function is passed as value to setInputs, pass previous state
   const setInputs = useMemo(
+    // @ts-ignore TYPE NEEDS FIXING
     () => (values) => dispatch(setAddNormalInput(typeof values === 'function' ? values(normalInput) : values)),
     [dispatch, normalInput]
   )

--- a/src/features/trident/swap/SwapAssetPanel.tsx
+++ b/src/features/trident/swap/SwapAssetPanel.tsx
@@ -23,7 +23,9 @@ import BentoBoxFundingSourceModal from '../add/BentoBoxFundingSourceModal'
 
 interface SwapAssetPanel {
   error: boolean
+  // @ts-ignore TYPE NEEDS FIXING
   header: (x) => React.ReactNode
+  // @ts-ignore TYPE NEEDS FIXING
   walletToggle: (x) => React.ReactNode
   currency?: Currency
   currencies?: string[]
@@ -254,6 +256,7 @@ const InputPanel: FC<
             {!currency ? (
               <CurrencySearchModal
                 selectedCurrency={currency}
+                // @ts-ignore TYPE NEEDS FIXING
                 {...(currencies?.length > 0 && { currencyList: currencies })}
                 onCurrencySelect={(currency) => onSelect && onSelect(currency)}
                 trigger={

--- a/src/features/trident/swap/WrapButton.tsx
+++ b/src/features/trident/swap/WrapButton.tsx
@@ -37,9 +37,11 @@ const WrapButton: FC = () => {
       return addTransaction(txReceipt, {
         summary: parsedAmounts?.[0]?.currency.isNative
           ? i18n._(
+              // @ts-ignore TYPE NEEDS FIXING
               t`Wrap ${parsedAmounts?.[0].toSignificant(6)} ${NATIVE[chainId].symbol} to ${WNATIVE[chainId].symbol}`
             )
           : i18n._(
+              // @ts-ignore TYPE NEEDS FIXING
               t`Unwrap ${parsedAmounts?.[0].toSignificant(6)} ${WNATIVE[chainId].symbol} to ${NATIVE[chainId].symbol}`
             ),
       })

--- a/src/features/trident/swap/_useSwapPage.ts
+++ b/src/features/trident/swap/_useSwapPage.ts
@@ -68,6 +68,7 @@ export const _useSwapPage = () => {
       trade.outputAmount?.currency.wrapped.address &&
       rebases[trade?.outputAmount?.currency.wrapped.address]
     )
+      // @ts-ignore TYPE NEEDS FIXING
       return toAmountCurrencyAmount(rebases[trade.outputAmount?.currency.wrapped.address], trade.outputAmount.wrapped)
 
     return undefined
@@ -96,7 +97,8 @@ export const _useSwapPage = () => {
         ? i18n._(t`Connect Wallet`)
         : maxAmountSpend(balance)?.equalTo(ZERO)
         ? i18n._(t`Insufficient balance to cover for fees`)
-        : !trade?.inputAmount[0]?.greaterThan(ZERO) && !parsedAmounts[1]?.greaterThan(ZERO)
+        : // @ts-ignore TYPE NEEDS FIXING
+        !trade?.inputAmount[0]?.greaterThan(ZERO) && !parsedAmounts[1]?.greaterThan(ZERO)
         ? i18n._(t`Enter an amount`)
         : trade === undefined && !isWrap
         ? i18n._(t`No route found`)

--- a/src/features/trident/useCurrenciesFromURL.ts
+++ b/src/features/trident/useCurrenciesFromURL.ts
@@ -14,6 +14,7 @@ const useCurrenciesFromURL = (): {
 } => {
   const { chainId } = useActiveWeb3React()
   const router = useRouter()
+  // @ts-ignore TYPE NEEDS FIXING
   const currencyA = useCurrency(router.query.tokens?.[0]) || (chainId && NATIVE[chainId]) || undefined
   const currencyB = useCurrency(router.query.tokens?.[1]) || (chainId && SUSHI[chainId]) || undefined
 
@@ -23,6 +24,7 @@ const useCurrenciesFromURL = (): {
   const switchCurrencies = useCallback(async () => {
     if (!chainId) return
 
+    // @ts-ignore TYPE NEEDS FIXING
     const nativeSymbol = NATIVE[chainId].symbol
     let tokens: string[] = []
     if (router.query && router.query.tokens) {
@@ -59,6 +61,7 @@ const useCurrenciesFromURL = (): {
     async (cur: Currency, index: number) => {
       if (!chainId) return
 
+      // @ts-ignore TYPE NEEDS FIXING
       const nativeSymbol = NATIVE[chainId].symbol
       let tokens: string[] = [
         currencyA?.isNative ? nativeSymbol : currencyA?.wrapped.address,
@@ -73,6 +76,7 @@ const useCurrenciesFromURL = (): {
           return switchCurrencies()
         }
 
+        // @ts-ignore TYPE NEEDS FIXING
         const newToken = cur.isNative ? NATIVE[chainId].symbol : cur.wrapped.address
         if (tokens.includes(newToken)) return // return if token already selected
         tokens[index] = newToken

--- a/src/features/trident/useDependentAssetInputs.ts
+++ b/src/features/trident/useDependentAssetInputs.ts
@@ -10,9 +10,12 @@ export type useDependentAssetInputs = (x: {
   fixedRatio: boolean
   spendFromWallet: [boolean, boolean]
   inputs: (string | undefined)[]
+  // @ts-ignore TYPE NEEDS FIXING
   setInputs(x): void
 }) => {
+  // @ts-ignore TYPE NEEDS FIXING
   mainInput: [string, (string) => void]
+  // @ts-ignore TYPE NEEDS FIXING
   secondaryInput: [string, (string) => void]
   onMax(): void
   isMax?: boolean
@@ -51,6 +54,7 @@ export const useDependentAssetInputs: useDependentAssetInputs = ({
         }
       }
 
+      // @ts-ignore TYPE NEEDS FIXING
       setInputs((prevState) => [val, Number(val) === 0 ? undefined : prevState[1]])
     },
     [currencies, fixedRatio, noLiquidity, poolWithState?.pool, rebases, setInputs]
@@ -79,6 +83,7 @@ export const useDependentAssetInputs: useDependentAssetInputs = ({
         }
       }
 
+      // @ts-ignore TYPE NEEDS FIXING
       setInputs((prevState) => [Number(val) === 0 ? undefined : prevState[0], val])
     },
     [currencies, fixedRatio, noLiquidity, poolWithState?.pool, rebases, setInputs]
@@ -135,7 +140,9 @@ export const useDependentAssetInputs: useDependentAssetInputs = ({
 
   return useMemo(
     () => ({
+      // @ts-ignore TYPE NEEDS FIXING
       mainInput: [inputs[0], handleMainInput] as [string, (string) => void],
+      // @ts-ignore TYPE NEEDS FIXING
       secondaryInput: [inputs[1], handleSecondaryInput] as [string, (string) => void],
       onMax,
       isMax,

--- a/src/features/user/TransactionList.tsx
+++ b/src/features/user/TransactionList.tsx
@@ -7,11 +7,13 @@ import { useActiveWeb3React } from 'app/services/web3'
 import React from 'react'
 import { ArrowUpRight, CheckCircle } from 'react-feather'
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function TransactionList({ transactions }) {
   const { i18n } = useLingui()
   const { chainId } = useActiveWeb3React()
   return transactions ? (
     <div className="space-y-3">
+      {/*@ts-ignore TYPE NEEDS FIXING*/}
       {transactions.map((transaction) => (
         <div key={transaction.tx_hash} className="flex items-center justify-between px-3 py-1 rounded bg-dark-800">
           <div className="flex flex-row items-center pr-3 space-x-1">

--- a/src/functions/array/enumToArray.ts
+++ b/src/functions/array/enumToArray.ts
@@ -5,8 +5,11 @@ type NonFunctional<T> = T extends Function ? never : T
  * @param enumeration Enumeration object.
  */
 export function enumToArray<T>(enumeration: T): NonFunctional<T[keyof T]>[] {
-  return Object.keys(enumeration)
-    .filter((key) => isNaN(Number(key)))
-    .map((key) => enumeration[key])
-    .filter((val) => typeof val === 'number' || typeof val === 'string')
+  return (
+    Object.keys(enumeration)
+      .filter((key) => isNaN(Number(key)))
+      // @ts-ignore TYPE NEEDS FIXING
+      .map((key) => enumeration[key])
+      .filter((val) => typeof val === 'number' || typeof val === 'string')
+  )
 }

--- a/src/functions/cloudinary.ts
+++ b/src/functions/cloudinary.ts
@@ -1,11 +1,13 @@
 import { ImageLoader, ImageLoaderProps } from 'next/image'
 
+// @ts-ignore TYPE NEEDS FIXING
 export const normalizeUrl = (src) => {
   return src[0] === '/' ? src.slice(1) : src
 }
 
 export const cloudinaryLoader: ImageLoader = ({
   src,
+  // @ts-ignore TYPE NEEDS FIXING
   width = undefined,
   height = undefined,
 }: ImageLoaderProps & { height?: number }) => {

--- a/src/functions/convert/apyApr.ts
+++ b/src/functions/convert/apyApr.ts
@@ -38,6 +38,7 @@ const BLOCKS_IN_A_YEAR = SECONDS_PER_YEAR / 13.25
  * @param frequency {Number} Compounding frequency (times a year)
  * @returns {Number} APR as percentage (ie. 5.82 for APY of 6%)
  */
+// @ts-ignore TYPE NEEDS FIXING
 export const apyToApr = (apy, frequency = BLOCKS_IN_A_YEAR) =>
   ((1 + apy / 100) ** (1 / frequency) - 1) * frequency * 100
 
@@ -48,4 +49,5 @@ export const apyToApr = (apy, frequency = BLOCKS_IN_A_YEAR) =>
  * @param frequency {Number} Compounding frequency (times a year)
  * @returns {Number} APY as percentage (ie. 6 for APR of 5.82%)
  */
+// @ts-ignore TYPE NEEDS FIXING
 export const aprToApy = (apr, frequency = BLOCKS_IN_A_YEAR) => ((1 + apr / 100 / frequency) ** frequency - 1) * 100

--- a/src/functions/convert/contenthashToUri.ts
+++ b/src/functions/convert/contenthashToUri.ts
@@ -1,5 +1,7 @@
 import CID from 'cids'
+// @ts-ignore TYPE NEEDS FIXING
 import { getCodec, rmPrefix } from 'multicodec'
+// @ts-ignore TYPE NEEDS FIXING
 import { decode, toB58String } from 'multihashes'
 
 export function hexToUint8Array(hex: string): Uint8Array {

--- a/src/functions/currency/wrappedCurrency.ts
+++ b/src/functions/currency/wrappedCurrency.ts
@@ -3,6 +3,7 @@ import { ChainId, Currency, NATIVE, WNATIVE } from '@sushiswap/core-sdk'
 export function unwrappedToken(currency: Currency): Currency {
   if (currency.isNative) return currency
 
+  // @ts-ignore TYPE NEEDS FIXING
   if (currency.chainId in ChainId && currency.equals(WNATIVE[currency.chainId])) return NATIVE[currency.chainId]
 
   return currency
@@ -11,6 +12,7 @@ export function unwrappedToken(currency: Currency): Currency {
 export const isWrappedReturnNativeSymbol = (chainId: ChainId | undefined, address: string) => {
   if (!chainId) return address
   if (address.toLowerCase() === WNATIVE[chainId].address.toLowerCase()) {
+    // @ts-ignore TYPE NEEDS FIXING
     return NATIVE[chainId].symbol
   }
 

--- a/src/functions/feature.ts
+++ b/src/functions/feature.ts
@@ -3,11 +3,16 @@ import features from 'app/config/features'
 import { Feature } from 'app/enums'
 
 export function featureEnabled(feature: Feature, chainId: ChainId): boolean {
+  // @ts-ignore TYPE NEEDS FIXING
   return chainId && chainId in features && features[chainId].includes(feature)
 }
 
 export function chainsWithFeature(feature: Feature): ChainId[] {
-  return Object.keys(features)
-    .filter((chainKey) => featureEnabled(feature, ChainId[chainKey]))
-    .map((chain) => ChainId[chain])
+  return (
+    Object.keys(features)
+      // @ts-ignore TYPE NEEDS FIXING
+      .filter((chainKey) => featureEnabled(feature, ChainId[chainKey]))
+      // @ts-ignore TYPE NEEDS FIXING
+      .map((chain) => ChainId[chain])
+  )
 }

--- a/src/functions/format.ts
+++ b/src/functions/format.ts
@@ -4,8 +4,10 @@ import { getAddress } from '@ethersproject/address'
 import { BigNumberish } from '@ethersproject/bignumber'
 import { formatUnits } from '@ethersproject/units'
 import { Currency, CurrencyAmount, Fraction, JSBI, Price } from '@sushiswap/core-sdk'
+// @ts-ignore TYPE NEEDS FIXING
 import Numeral from 'numeral'
 
+// @ts-ignore TYPE NEEDS FIXING
 export const capitalize = (s) => {
   if (typeof s !== 'string') return ''
   return s.charAt(0).toUpperCase() + s.slice(1)
@@ -40,6 +42,7 @@ const priceFormatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
 })
 
+// @ts-ignore TYPE NEEDS FIXING
 export function formatPercent(percentString) {
   const percent = parseFloat(percentString)
 

--- a/src/functions/gtag.ts
+++ b/src/functions/gtag.ts
@@ -1,13 +1,16 @@
 export const GOOGLE_ANALYTICS_TRACKING_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+// @ts-ignore TYPE NEEDS FIXING
 export const pageview = (url) => {
+  // @ts-ignore TYPE NEEDS FIXING
   window.gtag('config', GOOGLE_ANALYTICS_TRACKING_ID, {
     page_path: url,
   })
 }
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/events
+// @ts-ignore TYPE NEEDS FIXING
 export const event = ({ action, category, label, value }) => {
   window.gtag('event', action, {
     event_category: category,
@@ -17,6 +20,7 @@ export const event = ({ action, category, label, value }) => {
 }
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/exceptions
+// @ts-ignore TYPE NEEDS FIXING
 export const exception = ({ description, fatal }) => {
   window.gtag('event', 'exception', {
     description,

--- a/src/functions/kashi.ts
+++ b/src/functions/kashi.ts
@@ -106,9 +106,13 @@ export function addBorrowFee(amount: BigNumber): BigNumber {
 }
 
 export function getFraction({
+  // @ts-ignore TYPE NEEDS FIXING
   totalAssetBase,
+  // @ts-ignore TYPE NEEDS FIXING
   totalAssetElastic,
+  // @ts-ignore TYPE NEEDS FIXING
   totalBorrowElastic,
+  // @ts-ignore TYPE NEEDS FIXING
   token0: { totalSupplyBase, totalSupplyElastic },
 }) {
   return totalAssetBase / (Number(totalAssetElastic) + (totalBorrowElastic * totalSupplyBase) / totalSupplyElastic)

--- a/src/functions/oracle.ts
+++ b/src/functions/oracle.ts
@@ -7,12 +7,14 @@ import { IOracle } from 'app/interfaces'
 
 import { e10 } from './math'
 
+// @ts-ignore TYPE NEEDS FIXING
 export function getOracle(chainId: ChainId, address: string, data: string): IOracle {
   if (address.toLowerCase() === CHAINLINK_ORACLE_ADDRESS[chainId].toLowerCase()) {
     return new ChainlinkOracle(chainId, address, data)
   }
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function validateChainlinkOracleData(chainId = ChainId.ETHEREUM, collateral, asset, data) {
   const mapping = CHAINLINK_PRICE_FEED_MAP[chainId]
   if (!mapping) {

--- a/src/functions/prices.ts
+++ b/src/functions/prices.ts
@@ -60,6 +60,7 @@ export function computeRealizedLPFeeAmount(
     const realizedLPFee = computeRealizedLPFeePercent(trade)
 
     // the amount of the input that accrues to LPs
+    // @ts-ignore TYPE NEEDS FIXING
     return CurrencyAmount.fromRawAmount(trade.inputAmount.currency, trade.inputAmount.multiply(realizedLPFee).quotient)
   }
 

--- a/src/functions/retry.ts
+++ b/src/functions/retry.ts
@@ -57,6 +57,7 @@ export function retry<T>(
         if (completed) {
           break
         }
+        // @ts-ignore TYPE NEEDS FIXING
         if (n <= 0 || !error.isRetryableError) {
           reject(error)
           completed = true

--- a/src/functions/yupValidators.ts
+++ b/src/functions/yupValidators.ts
@@ -3,6 +3,7 @@ import * as yup from 'yup'
 
 export const addressValidator = yup.string().test('is-address', '${value} is not a valid address', (value) => {
   // Allow empty string
+  //@ts-ignore TYPE NEEDS FIXING
   if (value.length === 0) return true
 
   try {

--- a/src/guards/Network/index.tsx
+++ b/src/guards/Network/index.tsx
@@ -9,6 +9,7 @@ import { NETWORK_ICON, NETWORK_LABEL } from 'app/config/networks'
 import { Feature } from 'app/enums'
 import { SUPPORTED_NETWORKS } from 'app/modals/NetworkModal'
 import { useActiveWeb3React } from 'app/services/web3'
+// @ts-ignore TYPE NEEDS FIXING
 import cookie from 'cookie-cutter'
 import Image from 'next/image'
 import React, { FC, Fragment } from 'react'
@@ -38,12 +39,14 @@ const Component: FC<NetworkGuardProps> = ({ children, feature }) => {
   return (
     <>
       <HeadlessUIModal.Controlled
+        // @ts-ignore TYPE NEEDS FIXING
         isOpen={!!account && !features[chainId].includes(feature)}
         onDismiss={() => null}
         transparent={true}
       >
         <div className="flex flex-col gap-7 justify-center p-4 mt-10 lg:mt-0">
           <Typography variant="h1" className="max-w-2xl text-white text-center" weight={700}>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {i18n._(t`Roll it back - this feature is not yet supported on ${NETWORK_LABEL[chainId]}.`)}
           </Typography>
           <Typography className="text-center">
@@ -62,6 +65,7 @@ const Component: FC<NetworkGuardProps> = ({ children, feature }) => {
                 className="text-primary hover:text-white flex items-center flex-col gap-2 justify-start"
                 key={idx}
                 onClick={() => {
+                  // @ts-ignore TYPE NEEDS FIXING
                   const params = SUPPORTED_NETWORKS[key]
                   cookie.set('chainId', key)
                   if (key === ChainId.ETHEREUM.toString()) {
@@ -75,6 +79,7 @@ const Component: FC<NetworkGuardProps> = ({ children, feature }) => {
               >
                 <div className="w-[40px] h-[40px]">
                   <Image
+                    // @ts-ignore TYPE NEEDS FIXING
                     src={NETWORK_ICON[key]}
                     alt="Switch Network"
                     className="rounded-md filter drop-shadow-currencyLogo"
@@ -82,6 +87,7 @@ const Component: FC<NetworkGuardProps> = ({ children, feature }) => {
                     height="40px"
                   />
                 </div>
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <Typography className="text-sm">{NETWORK_LABEL[key]}</Typography>
               </button>
             ))}
@@ -94,6 +100,7 @@ const Component: FC<NetworkGuardProps> = ({ children, feature }) => {
 }
 
 const NetworkGuard = (feature: Feature) => {
+  // @ts-ignore TYPE NEEDS FIXING
   return ({ children }) => <Component feature={feature}>{children}</Component>
 }
 

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -185,11 +185,13 @@ export function useCurrency(currencyId: string | undefined): Currency | null | u
 
   const isETH = currencyId?.toUpperCase() === 'ETH'
 
+  // @ts-ignore TYPE NEEDS FIXING
   const isDual = [ChainId.CELO].includes(chainId)
 
   const useNative = isETH && !isDual
 
   if (isETH && isDual) {
+    // @ts-ignore TYPE NEEDS FIXING
     currencyId = WNATIVE_ADDRESS[chainId]
   }
 
@@ -197,6 +199,7 @@ export function useCurrency(currencyId: string | undefined): Currency | null | u
 
   const { native, wnative } = useMemo(
     () => ({
+      // @ts-ignore TYPE NEEDS FIXING
       native: chainId && chainId in NATIVE ? NATIVE[chainId] : undefined,
       wnative: chainId && chainId in WNATIVE ? WNATIVE[chainId] : undefined,
     }),

--- a/src/hooks/useBentoMasterApproveCallback.ts
+++ b/src/hooks/useBentoMasterApproveCallback.ts
@@ -130,6 +130,7 @@ const useBentoMasterApproveCallback = (
       return permit
     } catch (e) {
       return {
+        // @ts-ignore TYPE NEEDS FIXING
         outcome: e.code === 4001 ? BentoApproveOutcome.REJECTED : BentoApproveOutcome.FAILED,
       }
     }

--- a/src/hooks/useBentoOrWalletBalance.ts
+++ b/src/hooks/useBentoOrWalletBalance.ts
@@ -9,6 +9,7 @@ export const useBentoOrWalletBalances = (
   fromWallet?: (boolean | undefined)[]
 ) => {
   const tokenAddresses = useMemo(
+    // @ts-ignore TYPE NEEDS FIXING
     () => (currencies.every((el) => el) ? currencies.map((el: Currency) => el.wrapped.address) : undefined),
     [currencies]
   )

--- a/src/hooks/useColor.ts
+++ b/src/hooks/useColor.ts
@@ -3,6 +3,7 @@ import { uriToHttp } from 'app/functions/convert'
 import Vibrant from 'node-vibrant'
 import { shade } from 'polished'
 import { useLayoutEffect, useState } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import { hex } from 'wcag-contrast'
 
 async function getColorFromToken(token: Token): Promise<string | null> {

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -174,6 +174,7 @@ export function useFactoryContract(): Contract | null {
 
 export function useRouterContract(withSignerIfPossible?: boolean): Contract | null {
   const { chainId } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   return useContract(ROUTER_ADDRESS[chainId], ROUTER_ABI, withSignerIfPossible)
 }
 
@@ -206,10 +207,12 @@ export function useUniV2FactoryContract(): Contract | null {
   return useContract(UNI_FACTORY_ADDRESS, UNI_FACTORY_ABI, false)
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useComplexRewarderContract(address, withSignerIfPossible?: boolean): Contract | null {
   return useContract(address, COMPLEX_REWARDER_ABI, withSignerIfPossible)
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useCloneRewarderContract(address, withSignerIfPossibe?: boolean): Contract | null {
   return useContract(address, CLONE_REWARDER_ABI, withSignerIfPossibe)
 }
@@ -220,6 +223,7 @@ export function useMeowshiContract(withSignerIfPossible?: boolean): Contract | n
 
 export function useLimitOrderContract(withSignerIfPossibe?: boolean): Contract | null {
   const { chainId } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   return useContract(STOP_LIMIT_ORDER_ADDRESS[chainId], LIMIT_ORDER_ABI, withSignerIfPossibe)
 }
 
@@ -229,6 +233,7 @@ export function useLimitOrderHelperContract(withSignerIfPossible?: boolean): Con
     [ChainId.MATIC]: '0xe2f736B7d1f6071124CBb5FC23E93d141CD24E12',
     [ChainId.AVALANCHE]: '0x889ec9e19C1598358899fCA4879011686c3d4045',
   }
+  // @ts-ignore TYPE NEEDS FIXING
   return useContract(chainId && LIMIT_ORDER_HELPER_ADDRESS[chainId], LIMIT_ORDER_HELPER_ABI, withSignerIfPossible)
 }
 
@@ -242,30 +247,35 @@ export function useZenkoContract(withSignerIfPossible?: boolean): Contract | nul
 
 export function useTridentRouterContract(withSignerIfPossible?: boolean): Contract | null {
   const { chainId } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const router = TRIDENT[chainId]?.[CHAIN_KEY[chainId]]?.contracts.TridentRouter
   return useContract(router?.address, router?.abi, withSignerIfPossible)
 }
 
 export function useMasterDeployerContract(withSignerIfPossible?: boolean): Contract | null {
   const { chainId } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const masterDeployer = TRIDENT[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MasterDeployer
   return useContract(masterDeployer?.address, masterDeployer?.abi, withSignerIfPossible)
 }
 
 export function useConstantProductPoolFactory(withSignerIfPossible?: boolean): Contract | null {
   const { chainId } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const factory = TRIDENT[chainId]?.[CHAIN_KEY[chainId]]?.contracts.ConstantProductPoolFactory
   return useContract(factory?.address, factory?.abi, withSignerIfPossible)
 }
 
 export function useStablePoolFactory(withSignerIfPossible?: boolean): Contract | null {
   const { chainId } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const factory = TRIDENT[chainId]?.[CHAIN_KEY[chainId]]?.contracts.HybridPoolFactory
   return useContract(factory?.address, factory?.abi, withSignerIfPossible)
 }
 
 export function useMisoHelperContract(withSignerIfPossible = true): Contract | null {
   const { chainId } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const factory = MISO[chainId]?.[CHAIN_KEY[chainId]]?.contracts.MISOHelper
   return useContract(factory?.address, MISO_HELPER_ABI, withSignerIfPossible)
 }

--- a/src/hooks/useERC20Permit.ts
+++ b/src/hooks/useERC20Permit.ts
@@ -47,6 +47,7 @@ const PERMITTABLE_TOKENS: {
       name: 'Dai Stablecoin',
       version: '1',
     },
+    // @ts-ignore TYPE NEEDS FIXING
     [SUSHI[1].address]: { type: PermitType.AMOUNT, name: 'SushiSwap' },
   },
   [4]: {
@@ -55,9 +56,11 @@ const PERMITTABLE_TOKENS: {
       name: 'Dai Stablecoin',
       version: '1',
     },
+    // @ts-ignore TYPE NEEDS FIXING
     [SUSHI[4].address]: { type: PermitType.AMOUNT, name: 'SushiSwap' },
   },
   [3]: {
+    // @ts-ignore TYPE NEEDS FIXING
     [SUSHI[3].address]: { type: PermitType.AMOUNT, name: 'SushiSwap' },
     ['0x07865c6E87B9F70255377e024ace6630C1Eaa37F']: {
       type: PermitType.AMOUNT,
@@ -66,9 +69,11 @@ const PERMITTABLE_TOKENS: {
     },
   },
   [5]: {
+    // @ts-ignore TYPE NEEDS FIXING
     [SUSHI[5].address]: { type: PermitType.AMOUNT, name: 'SushiSwap' },
   },
   [42]: {
+    // @ts-ignore TYPE NEEDS FIXING
     [SUSHI[42].address]: { type: PermitType.AMOUNT, name: 'SushiSwap' },
   },
 }

--- a/src/hooks/useEagerConnect.ts
+++ b/src/hooks/useEagerConnect.ts
@@ -16,6 +16,7 @@ function useEagerConnect() {
           .catch(() => {
             setTried(true)
           })
+        // @ts-ignore TYPE NEEDS FIXING
         window.ethereum.removeAllListeners(['networkChanged'])
       } else {
         if (isMobile && window.ethereum) {
@@ -24,6 +25,7 @@ function useEagerConnect() {
             .catch(() => {
               setTried(true)
             })
+          // @ts-ignore TYPE NEEDS FIXING
           window.ethereum.removeAllListeners(['networkChanged'])
         } else {
           setTried(true)

--- a/src/hooks/useFarmRewards.ts
+++ b/src/hooks/useFarmRewards.ts
@@ -31,12 +31,14 @@ import { useMemo } from 'react'
 export default function useFarmRewards() {
   const { chainId } = useActiveWeb3React()
 
+  // @ts-ignore TYPE NEEDS FIXING
   const positions = usePositions(chainId)
 
   // console.log({ positions })
 
   const block1d = useOneDayBlock({ chainId, shouldFetch: !!chainId })
 
+  // @ts-ignore TYPE NEEDS FIXING
   const farms = useFarms({ chainId })
 
   const farmAddresses = useMemo(() => farms.map((farm) => farm.pair), [farms])
@@ -101,13 +103,17 @@ export default function useFarmRewards() {
 
   const blocksPerDay = 86400 / Number(averageBlockTime)
 
+  // @ts-ignore TYPE NEEDS FIXING
   const map = (pool) => {
     // TODO: Deal with inconsistencies between properties on subgraph
     pool.owner = pool?.owner || pool?.masterChef || pool?.miniChef
     pool.balance = pool?.balance || pool?.slpBalance
 
+    // @ts-ignore TYPE NEEDS FIXING
     const swapPair = swapPairs?.find((pair) => pair.id === pool.pair)
+    // @ts-ignore TYPE NEEDS FIXING
     const swapPair1d = swapPairs1d?.find((pair) => pair.id === pool.pair)
+    // @ts-ignore TYPE NEEDS FIXING
     const kashiPair = kashiPairs?.find((pair) => pair.id === pool.pair)
 
     const pair = swapPair || kashiPair
@@ -123,6 +129,7 @@ export default function useFarmRewards() {
         (pool?.owner?.sushiPerSecond / 1e18) * averageBlockTime ||
         masterChefV1SushiPerBlock
 
+      // @ts-ignore TYPE NEEDS FIXING
       const rewardPerBlock = (pool.allocPoint / pool.owner.totalAllocPoint) * sushiPerBlock
 
       const defaultReward = {
@@ -133,6 +140,7 @@ export default function useFarmRewards() {
       }
 
       let rewards: { currency: Currency; rewardPerBlock: number; rewardPerDay: number; rewardPrice: number }[] = [
+        // @ts-ignore TYPE NEEDS FIXING
         defaultReward,
       ]
 
@@ -244,12 +252,15 @@ export default function useFarmRewards() {
           // Secondary reward only
           rewards[0] = reward[ChainId.FUSE]
         } else {
+          // @ts-ignore TYPE NEEDS FIXING
           rewards[0] = {
             ...defaultReward,
             rewardPerBlock: sushiPerBlock,
             rewardPerDay: sushiPerDay,
           }
+          // @ts-ignore TYPE NEEDS FIXING
           if (chainId in reward) {
+            // @ts-ignore TYPE NEEDS FIXING
             rewards[1] = reward[chainId]
           }
         }
@@ -312,13 +323,16 @@ export default function useFarmRewards() {
           },
         }
 
+        // @ts-ignore TYPE NEEDS FIXING
         rewards[0] = {
           ...defaultReward,
           rewardPerBlock: sushiPerBlock,
           rewardPerDay: sushiPerDay,
         }
 
+        // @ts-ignore TYPE NEEDS FIXING
         if (chainId in reward) {
+          // @ts-ignore TYPE NEEDS FIXING
           rewards[1] = reward[chainId]
         }
       }
@@ -390,7 +404,9 @@ export default function useFarmRewards() {
   return farms
     .filter((farm) => {
       return (
+        // @ts-ignore TYPE NEEDS FIXING
         (swapPairs && swapPairs.find((pair) => pair.id === farm.pair)) ||
+        // @ts-ignore TYPE NEEDS FIXING
         (kashiPairs && kashiPairs.find((pair) => pair.id === farm.pair))
       )
     })

--- a/src/hooks/useFuse.ts
+++ b/src/hooks/useFuse.ts
@@ -1,11 +1,14 @@
 import Fuse from 'fuse.js'
 import { useState } from 'react'
 
+// @ts-ignore TYPE NEEDS FIXING
 function fuzzySearch({ fuse, data, term }) {
   const results = fuse.search(term)
+  // @ts-ignore TYPE NEEDS FIXING
   return term ? results.map((result) => result.item) : data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 function useFuse({ data, options }) {
   const [term, setTerm] = useState<string>('')
   const fuseOptions = {

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -5,6 +5,7 @@ import { Dispatch, useEffect, useState } from 'react'
   to minimize this impact. This hook pairs with it, keeping track of visible
   items and passes this to <InfiniteScroll> component.
 */
+// @ts-ignore TYPE NEEDS FIXING
 export function useInfiniteScroll(items): [number, Dispatch<number>] {
   const [itemsDisplayed, setItemsDisplayed] = useState(10)
   useEffect(() => setItemsDisplayed(15), [items.length])

--- a/src/hooks/useKashiApproveCallback.ts
+++ b/src/hooks/useKashiApproveCallback.ts
@@ -113,6 +113,7 @@ function useKashiApproveCallback(): [
       }
     } catch (e) {
       return {
+        // @ts-ignore TYPE NEEDS FIXING
         outcome: e.code === 4001 ? BentoApproveOutcome.REJECTED : BentoApproveOutcome.FAILED,
       }
     }

--- a/src/hooks/useLimitOrderApproveCallback.ts
+++ b/src/hooks/useLimitOrderApproveCallback.ts
@@ -109,6 +109,7 @@ const useLimitOrderApproveCallback = () => {
     } catch (error) {
       console.log(error)
       return {
+        // @ts-ignore TYPE NEEDS FIXING
         outcome: error.code === 4001 ? BentoApproveOutcome.REJECTED : BentoApproveOutcome.FAILED,
       }
     }
@@ -123,6 +124,7 @@ const useLimitOrderApproveCallback = () => {
     } else {
       const { outcome, signature, data } = await approve()
 
+      // @ts-ignore TYPE NEEDS FIXING
       if (outcome === BentoApproveOutcome.SUCCESS) setLimitOrderPermit({ signature, data })
       else setFallback(true)
     }
@@ -163,6 +165,7 @@ const useLimitOrderApproveCallback = () => {
 
         const tx = await limitOrderHelperContract?.depositAndApprove(account, masterContract, true, v, r, s, {
           value: amount,
+          // @ts-ignore TYPE NEEDS FIXING
           gasLimit: calculateGasMargin(estimatedGas),
         })
 
@@ -173,6 +176,7 @@ const useLimitOrderApproveCallback = () => {
 
       // If bento is not yet approved but we do have the permit, add the permit to the batch
       if (approvalState === BentoApprovalState.NOT_APPROVED && limitOrderPermit) {
+        // @ts-ignore TYPE NEEDS FIXING
         batch.push(limitOrderPermit.data)
         summary.push('Approve Limit Order')
       }

--- a/src/hooks/useLimitOrders.ts
+++ b/src/hooks/useLimitOrders.ts
@@ -37,6 +37,7 @@ interface OpenOrder {
 const denominator = (decimals: number = 18) => JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(decimals))
 
 const viewUrl = `${LAMBDA_URL}/orders/view`
+// @ts-ignore TYPE NEEDS FIXING
 const viewFetcher = (url, account, chainId, pendingPage, page) => {
   return fetch(url, {
     method: 'POST',
@@ -143,7 +144,9 @@ const useLimitOrders = () => {
     }
 
     ;(async () => {
+      // @ts-ignore TYPE NEEDS FIXING
       const openOrders = await Promise.all<OpenOrder>(ordersData.pendingOrders.orders.map((el) => transform(el)))
+      // @ts-ignore TYPE NEEDS FIXING
       const completedOrders = await Promise.all<OpenOrder>(ordersData.otherOrders.orders.map((el) => transform(el)))
 
       setState((prevState) => ({

--- a/src/hooks/useStickyData.ts
+++ b/src/hooks/useStickyData.ts
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 
+// @ts-ignore TYPE NEEDS FIXING
 function useStickyData(value) {
   const val = useRef()
   if (value !== undefined) val.current = value

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -344,6 +344,7 @@ export function useSwapCallArguments(
   return useMemo<SwapCall[]>(() => {
     let result: SwapCall[] = []
     if (
+      // @ts-ignore TYPE NEEDS FIXING
       (featureEnabled(Feature.BENTOBOX, chainId) && !rebase) ||
       !trade ||
       !recipient ||
@@ -433,6 +434,7 @@ export function useSwapCallArguments(
 
       const actions = [
         approveMasterContractAction({ router: tridentRouterContract, signature: bentoPermit }),
+        // @ts-ignore TYPE NEEDS FIXING
         tridentRouterContract.interface.encodeFunctionData(method[routeType], [rest]),
       ]
 
@@ -534,6 +536,7 @@ export function useSwapCallback(
   const blockNumber = useBlockNumber()
 
   const eip1559 =
+    // @ts-ignore TYPE NEEDS FIXING
     EIP_1559_ACTIVATION_BLOCK[chainId] == undefined ? false : blockNumber >= EIP_1559_ACTIVATION_BLOCK[chainId]
 
   const swapCalls = useSwapCallArguments(
@@ -669,6 +672,7 @@ export function useSwapCallback(
           const supportedNetwork = OPENMEV_SUPPORTED_NETWORKS.includes(chainId)
           if (!supportedNetwork) throw new Error(`Unsupported OpenMEV network id ${chainId} when building transaction`)
 
+          // @ts-ignore TYPE NEEDS FIXING
           txResponse = library
             .getSigner()
             .populateTransaction({
@@ -692,6 +696,7 @@ export function useSwapCallback(
                 data: data?.toString(),
               })
 
+              // @ts-ignore TYPE NEEDS FIXING
               return library.provider
                 .request({ method: 'eth_sign', params: [account, hexlify(txToSign.getMessageToSign())] })
                 .then((signature) => {
@@ -710,6 +715,7 @@ export function useSwapCallback(
                 params: [signedTx],
               })
 
+              // @ts-ignore TYPE NEEDS FIXING
               return fetch(OPENMEV_URI[chainId], {
                 method: 'POST',
                 body,
@@ -741,8 +747,10 @@ export function useSwapCallback(
             } for ${trade?.outputAmount?.toSignificant(4)} ${trade?.outputAmount.currency?.symbol}`
             if (tridentTradeContext?.parsedAmounts) {
               base = `Swap ${tridentTradeContext?.parsedAmounts[0]?.toSignificant(4)} ${
+                // @ts-ignore TYPE NEEDS FIXING
                 tridentTradeContext?.parsedAmounts[0].currency?.symbol
               } for ${tridentTradeContext?.parsedAmounts[1]?.toSignificant(4)} ${
+                // @ts-ignore TYPE NEEDS FIXING
                 tridentTradeContext?.parsedAmounts[1].currency?.symbol
               }`
             }

--- a/src/hooks/useWrapCallback.ts
+++ b/src/hooks/useWrapCallback.ts
@@ -56,6 +56,7 @@ export default function useWrapCallback(
                     value: `0x${inputAmount.quotient.toString(16)}`,
                   })
                   addTransaction(txReceipt, {
+                    // @ts-ignore TYPE NEEDS FIXING
                     summary: `Wrap ${inputAmount.toSignificant(6)} ${NATIVE[chainId].symbol} to ${
                       WNATIVE[chainId].symbol
                     }`,
@@ -68,8 +69,10 @@ export default function useWrapCallback(
         inputError: sufficientBalance
           ? undefined
           : hasInputAmount
-          ? `Insufficient ${NATIVE[chainId].symbol} balance`
-          : `Enter ${NATIVE[chainId].symbol} amount`,
+          ? // @ts-ignore TYPE NEEDS FIXING
+            `Insufficient ${NATIVE[chainId].symbol} balance`
+          : // @ts-ignore TYPE NEEDS FIXING
+            `Enter ${NATIVE[chainId].symbol} amount`,
       }
     } else if (weth.equals(inputCurrency) && outputCurrency.isNative) {
       return {
@@ -81,6 +84,7 @@ export default function useWrapCallback(
                   const txReceipt = await wethContract.withdraw(`0x${inputAmount.quotient.toString(16)}`)
                   addTransaction(txReceipt, {
                     summary: `Unwrap ${inputAmount.toSignificant(6)} ${WNATIVE[chainId].symbol} to ${
+                      // @ts-ignore TYPE NEEDS FIXING
                       NATIVE[chainId].symbol
                     }`,
                   })

--- a/src/hooks/useXSushiPerSushi.ts
+++ b/src/hooks/useXSushiPerSushi.ts
@@ -7,6 +7,7 @@ const QUERY = `{
     }
 }`
 
+// @ts-ignore TYPE NEEDS FIXING
 const fetcher = (query) => request('https://api.thegraph.com/subgraphs/name/matthewlilley/bar', query)
 
 // Returns ratio of XSushi:Sushi

--- a/src/layouts/Default/index.tsx
+++ b/src/layouts/Default/index.tsx
@@ -2,6 +2,8 @@ import Footer from 'app/components/Footer'
 import Header from 'app/components/Header'
 import Main from 'app/components/Main'
 import Popups from 'app/components/Popups'
+
+// @ts-ignore TYPE NEEDS FIXING
 const Layout = ({ children }) => {
   return (
     <div className="z-0 flex flex-col items-center w-full h-screen">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,6 +3,7 @@ export function getStrapiURL(path = '') {
 }
 
 // Helper to make GET requests to Strapi
+// @ts-ignore TYPE NEEDS FIXING
 export async function fetchAPI(path) {
   const requestUrl = getStrapiURL(path)
   const response = await fetch(requestUrl)

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,3 +1,4 @@
+// @ts-ignore TYPE NEEDS FIXING
 export function getStrapiMedia(url) {
   return url.startsWith('/') ? `${process.env.NEXT_PUBLIC_STRAPI_API_URL || 'http://localhost:1337'}${url}` : url
 }

--- a/src/modals/NetworkModal/index.tsx
+++ b/src/modals/NetworkModal/index.tsx
@@ -8,6 +8,7 @@ import { classNames } from 'app/functions'
 import { useActiveWeb3React } from 'app/services/web3'
 import { ApplicationModal } from 'app/state/application/actions'
 import { useModalOpen, useNetworkModalToggle } from 'app/state/application/hooks'
+// @ts-ignore TYPE NEEDS FIXING
 import cookie from 'cookie-cutter'
 import Image from 'next/image'
 import React, { FC } from 'react'
@@ -234,6 +235,7 @@ const NetworkModal: FC = () => {
                   className="bg-[rgba(0,0,0,0.2)] focus:outline-none flex items-center gap-4 w-full px-4 py-3 rounded border border-purple cursor-default"
                 >
                   <Image
+                    // @ts-ignore TYPE NEEDS FIXING
                     src={NETWORK_ICON[key]}
                     alt="Switch Network"
                     className="rounded-md"
@@ -259,6 +261,7 @@ const NetworkModal: FC = () => {
                     await library?.send('wallet_switchEthereumChain', [{ chainId: `0x${key.toString(16)}` }, account])
                   } catch (switchError) {
                     // This error code indicates that the chain has not been added to MetaMask.
+                    // @ts-ignore TYPE NEEDS FIXING
                     if (switchError.code === 4902) {
                       try {
                         await library?.send('wallet_addEthereumChain', [params, account])
@@ -275,6 +278,7 @@ const NetworkModal: FC = () => {
                   'bg-[rgba(0,0,0,0.2)] focus:outline-none flex items-center gap-4 w-full px-4 py-3 rounded border border-dark-700 hover:border-blue'
                 )}
               >
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <Image src={NETWORK_ICON[key]} alt="Switch Network" className="rounded-md" width="32px" height="32px" />
                 <Typography weight={700} className="text-high-emphesis">
                   {NETWORK_LABEL[key]}

--- a/src/modals/SearchModal/CurrencyList.tsx
+++ b/src/modals/SearchModal/CurrencyList.tsx
@@ -15,7 +15,9 @@ import { useCombinedActiveList } from 'app/state/lists/hooks'
 import { WrappedTokenInfo } from 'app/state/lists/wrappedTokenInfo'
 import { useCurrencyBalance } from 'app/state/wallet/hooks'
 import React, { CSSProperties, FC, useCallback, useMemo } from 'react'
+// @ts-ignore TYPE NEEDS FIXING
 import AutoSizer from 'react-virtualized-auto-sizer'
+// @ts-ignore TYPE NEEDS FIXING
 import { FixedSizeList as List } from 'react-window'
 
 function currencyKey(currency: Currency): string {
@@ -165,6 +167,7 @@ const CurrencyList: FC<CurrencyList> = ({ currencies, otherListTokens }) => {
   return (
     <div id="all-currencies-list" className="flex flex-col flex-1 flex-grow h-full divide-y divide-dark-800">
       <AutoSizer>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         {({ height, width }) => (
           <List height={height} width={width} itemCount={itemData.length} itemSize={56}>
             {Row}

--- a/src/modals/SearchModal/CurrencySearch.tsx
+++ b/src/modals/SearchModal/CurrencySearch.tsx
@@ -48,6 +48,7 @@ export function CurrencySearch({
 
   if (router.asPath.startsWith('/kashi/create') && chainId) {
     allTokens = Object.keys(allTokens).reduce((obj, key) => {
+      // @ts-ignore TYPE NEEDS FIXING
       if (CHAINLINK_TOKENS[chainId].find((address) => address === key)) obj[key] = allTokens[key]
       return obj
     }, {})
@@ -55,6 +56,7 @@ export function CurrencySearch({
 
   if (currencyList) {
     allTokens = Object.keys(allTokens).reduce((obj, key) => {
+      // @ts-ignore TYPE NEEDS FIXING
       if (currencyList.includes(key)) obj[key] = allTokens[key]
       return obj
     }, {})
@@ -79,6 +81,7 @@ export function CurrencySearch({
   }, [filteredTokens, tokenComparator])
 
   const filteredSortedTokens = useSortedTokensByQuery(sortedTokens, debouncedQuery)
+  // @ts-ignore TYPE NEEDS FIXING
   const ether = useMemo(() => chainId && ![ChainId.CELO].includes(chainId) && NATIVE[chainId], [chainId])
 
   const filteredSortedTokensWithETH: Currency[] = useMemo(() => {

--- a/src/modals/SearchModal/CurrencySearchModal.tsx
+++ b/src/modals/SearchModal/CurrencySearchModal.tsx
@@ -154,6 +154,7 @@ interface CurrencySearchModalProps extends Omit<ComponentProps, 'onDismiss'> {
 const CurrencySearchModal: CurrencySearchModal<CurrencySearchModalProps> = ({ trigger, ...props }) => {
   return (
     <HeadlessUiModal trigger={trigger}>
+      {/*@ts-ignore TYPE NEEDS FIXING*/}
       {({ setOpen }) => {
         return <Component {...props} onDismiss={() => setOpen(false)} />
       }}

--- a/src/modals/WalletModal/Option.tsx
+++ b/src/modals/WalletModal/Option.tsx
@@ -26,6 +26,7 @@ export default function Option({
   const content = (
     <div
       role="button"
+      // @ts-ignore TYPE NEEDS FIXING
       onClick={onClick}
       className={classNames(
         clickable ? 'cursor-pointer' : '',

--- a/src/modals/WalletModal/index.tsx
+++ b/src/modals/WalletModal/index.tsx
@@ -110,6 +110,7 @@ const WalletModal: FC<WalletModal> = ({ pendingTransactions, confirmedTransactio
       conn &&
         activate(conn, undefined, true).catch((error) => {
           if (error instanceof UnsupportedChainIdError) {
+            // @ts-ignore TYPE NEEDS FIXING
             activate(conn) // a little janky...can't use setError because the connector isn't set
           } else {
             setPendingError(true)
@@ -237,7 +238,9 @@ const WalletModal: FC<WalletModal> = ({ pendingTransactions, confirmedTransactio
           />
           {walletView === WALLET_VIEWS.PENDING ? (
             <PendingView
+              // @ts-ignore TYPE NEEDS FIXING
               id={pendingWallet.id}
+              // @ts-ignore TYPE NEEDS FIXING
               connector={pendingWallet.connector}
               error={pendingError}
               setPendingError={setPendingError}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import Web3ReactManager from 'app/components/Web3ReactManager'
 import getLibrary from 'app/functions/getLibrary'
 import { exception, GOOGLE_ANALYTICS_TRACKING_ID, pageview } from 'app/functions/gtag'
 import DefaultLayout from 'app/layouts/Default'
+// @ts-ignore TYPE NEEDS FIXING
 import store, { persistor } from 'app/state'
 import ApplicationUpdater from 'app/state/application/updater'
 import ListsUpdater from 'app/state/lists/updater'
@@ -34,16 +35,19 @@ if (typeof window !== 'undefined' && !!window.ethereum) {
   window.ethereum.autoRefreshOnNetworkChange = false
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 function MyApp({ Component, pageProps, fallback }) {
   const router = useRouter()
   const { locale, events } = router
 
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     const handleRouteChange = (url) => {
       pageview(url)
     }
     events.on('routeChangeComplete', handleRouteChange)
 
+    // @ts-ignore TYPE NEEDS FIXING
     const handleError = (error) => {
       exception({
         description: `${error.message} @ ${error.filename}:${error.lineno}:${error.colno}`,
@@ -60,7 +64,9 @@ function MyApp({ Component, pageProps, fallback }) {
   }, [events])
 
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     async function load(locale) {
+      // @ts-ignore TYPE NEEDS FIXING
       i18n.loadLocaleData(locale, { plurals: plurals[locale.split('_')[0]] })
 
       try {
@@ -125,6 +131,7 @@ function MyApp({ Component, pageProps, fallback }) {
         <Web3ReactProvider getLibrary={getLibrary}>
           <Web3ProviderNetwork getLibrary={getLibrary}>
             <Web3ReactManager>
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <ReduxProvider store={store}>
                 <PersistGate loading={<Dots>loading</Dots>} persistor={persistor}>
                   <>

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,7 +1,9 @@
+// @ts-ignore TYPE NEEDS FIXING
 function Error({ statusCode }) {
   return <p>{statusCode ? `An error ${statusCode} occurred on server` : 'An error occurred on client'}</p>
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 Error.getInitialProps = ({ res, err }) => {
   const statusCode = res ? res.statusCode : err ? err.statusCode : 404
   return { statusCode }

--- a/src/pages/analytics/bentobox/index.tsx
+++ b/src/pages/analytics/bentobox/index.tsx
@@ -30,23 +30,28 @@ export default function BentoBox(): JSX.Element {
   const tokenIdToPrice = useMemo<
     Map<string, { derivedETH: number; volumeUSD: number; dayData: Array<{ priceUSD: number }> }>
   >(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     return new Map(tokens?.map((token) => [token.id, token]))
   }, [tokens])
 
   const token1dIdToPrice = useMemo<Map<string, { derivedETH: number; volumeUSD: number }>>(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     return new Map(tokens1d?.map((token) => [token.id, token]))
   }, [tokens1d])
 
   const token1wIdToPrice = useMemo<Map<string, { derivedETH: number; volumeUSD: number }>>(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     return new Map(tokens1w?.map((token) => [token.id, token]))
   }, [tokens1w])
 
+  // @ts-ignore TYPE NEEDS FIXING
   const bentoBox = useBentoBox({ chainId, shouldFetch: featureEnabled(Feature.BENTOBOX, chainId) })
 
   // Combine Bento Box Tokens with Token data from exchange
   const bentoBoxTokensFormatted = useMemo<Array<any>>(
     () =>
       (bentoBox?.tokens || [])
+        // @ts-ignore TYPE NEEDS FIXING
         .map(({ id, totalSupplyElastic, decimals, symbol, name }) => {
           const token = tokenIdToPrice.get(id)
           const token1d = token1dIdToPrice.get(id)

--- a/src/pages/analytics/dashboard/index.tsx
+++ b/src/pages/analytics/dashboard/index.tsx
@@ -61,14 +61,18 @@ export default function Dashboard(): JSX.Element {
       liquidity: exchange?.liquidityUSD,
       liquidityChange: (exchange1d?.liquidityUSD / exchange2d?.liquidityUSD) * 100 - 100,
       liquidityChart: dayData
+        // @ts-ignore TYPE NEEDS FIXING
         ?.sort((a, b) => a.date - b.date)
+        // @ts-ignore TYPE NEEDS FIXING
         .map((day) => ({ x: new Date(day.date * 1000), y: Number(day.liquidityUSD) })),
 
       volume1d: exchange?.volumeUSD - exchange1d?.volumeUSD,
       volume1dChange:
         ((exchange?.volumeUSD - exchange1d?.volumeUSD) / (exchange1d?.volumeUSD - exchange2d?.volumeUSD)) * 100 - 100,
       volumeChart: dayData
+        // @ts-ignore TYPE NEEDS FIXING
         ?.sort((a, b) => a.date - b.date)
+        // @ts-ignore TYPE NEEDS FIXING
         .map((day) => ({ x: new Date(day.date * 1000), y: Number(day.volumeUSD) })),
     }),
     [exchange, exchange1d, exchange2d, dayData]
@@ -81,8 +85,11 @@ export default function Dashboard(): JSX.Element {
 
   const pairsFormatted = useMemo(
     () =>
+      // @ts-ignore TYPE NEEDS FIXING
       pairs?.map((pair) => {
+        // @ts-ignore TYPE NEEDS FIXING
         const pair1d = pairs1d?.find((p) => pair.id === p.id) ?? pair
+        // @ts-ignore TYPE NEEDS FIXING
         const pair1w = pairs1w?.find((p) => pair.id === p.id) ?? pair1d
 
         return {
@@ -136,8 +143,11 @@ export default function Dashboard(): JSX.Element {
   const tokensFormatted = useMemo(
     () =>
       tokens && tokens1d && tokens1w && nativePrice && nativePrice1d && nativePrice1w
-        ? tokens.map((token) => {
+        ? // @ts-ignore TYPE NEEDS FIXING
+          tokens.map((token) => {
+            // @ts-ignore TYPE NEEDS FIXING
             const token1d = tokens1d.find((p) => token.id === p.id) ?? token
+            // @ts-ignore TYPE NEEDS FIXING
             const token1w = tokens1w.find((p) => token.id === p.id) ?? token
 
             return {
@@ -155,6 +165,7 @@ export default function Dashboard(): JSX.Element {
               graph: token.dayData
                 .slice(0)
                 .reverse()
+                // @ts-ignore TYPE NEEDS FIXING
                 .map((day, i) => ({ x: i, y: Number(day.priceUSD) })),
             }
           })

--- a/src/pages/analytics/pairs/[id].tsx
+++ b/src/pages/analytics/pairs/[id].tsx
@@ -75,13 +75,17 @@ export default function Pair() {
       liquidity: pair?.reserveUSD,
       liquidityChange: (pair?.reserveUSD / pair1d?.reserveUSD) * 100 - 100,
       liquidityChart: pairDayData
+        // @ts-ignore TYPE NEEDS FIXING
         ?.sort((a, b) => a.date - b.date)
+        // @ts-ignore TYPE NEEDS FIXING
         .map((day) => ({ x: new Date(day.date * 1000), y: Number(day.reserveUSD) })),
 
       volume1d: pair?.volumeUSD - pair1d?.volumeUSD,
       volume1dChange: ((pair?.volumeUSD - pair1d?.volumeUSD) / (pair1d?.volumeUSD - pair2d?.volumeUSD)) * 100 - 100,
       volumeChart: pairDayData
+        // @ts-ignore TYPE NEEDS FIXING
         ?.sort((a, b) => a.date - b.date)
+        // @ts-ignore TYPE NEEDS FIXING
         .map((day) => ({ x: new Date(day.date * 1000), y: Number(day.volumeUSD) })),
     }),
     [pair, pair1d, pair2d, pairDayData]
@@ -135,7 +139,9 @@ export default function Pair() {
             <DoubleCurrencyLogo
               className="-space-x-3"
               logoClassName="rounded-full"
+              /* @ts-ignore TYPE NEEDS FIXING */
               currency0={currency0}
+              /* @ts-ignore TYPE NEEDS FIXING */
               currency1={currency1}
               size={54}
             />
@@ -186,6 +192,7 @@ export default function Pair() {
           {times(2).map((i) => (
             <div key={i} className="w-full p-6 space-y-2 border rounded bg-dark-900 border-dark-700">
               <div className="flex flex-row items-center space-x-2">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <CurrencyLogo size={32} currency={[currency0, currency1][i]} />
                 <div className="text-2xl font-bold">{formatNumber([pair?.reserve0, pair?.reserve1][i])}</div>
                 <div className="text-lg text-secondary">{[pair?.token0, pair?.token1][i]?.symbol}</div>

--- a/src/pages/analytics/pairs/index.tsx
+++ b/src/pages/analytics/pairs/index.tsx
@@ -26,8 +26,11 @@ export default function Pairs() {
 
   const pairsFormatted = useMemo(() => {
     return type === 'all'
-      ? pairs?.map((pair) => {
+      ? // @ts-ignore TYPE NEEDS FIXING
+        pairs?.map((pair) => {
+          // @ts-ignore TYPE NEEDS FIXING
           const pair1d = pairs1d?.find((p) => pair.id === p.id) ?? pair
+          // @ts-ignore TYPE NEEDS FIXING
           const pair1w = pairs1w?.find((p) => pair.id === p.id) ?? pair1d
 
           return {
@@ -42,10 +45,15 @@ export default function Pairs() {
           }
         })
       : pairs
+          // @ts-ignore TYPE NEEDS FIXING
           ?.map((pair) => {
+            // @ts-ignore TYPE NEEDS FIXING
             const pair1d = pairs1d?.find((p) => pair.id === p.id) ?? pair
+            // @ts-ignore TYPE NEEDS FIXING
             const pair2d = pairs2d?.find((p) => pair.id === p.id) ?? pair1d
+            // @ts-ignore TYPE NEEDS FIXING
             const pair1w = pairs1w?.find((p) => pair.id === p.id) ?? pair2d
+            // @ts-ignore TYPE NEEDS FIXING
             const pair2w = pairs2w?.find((p) => pair.id === p.id) ?? pair1w
 
             return {
@@ -67,6 +75,7 @@ export default function Pairs() {
                 ((pair.volumeUSD - pair1w.volumeUSD) / (pair1w.volumeUSD - pair2w.volumeUSD)) * 100 - 100,
             }
           })
+          // @ts-ignore TYPE NEEDS FIXING
           .sort((a, b) => b.liquidityChangeNumber1d - a.liquidityChangeNumber1d)
   }, [type, pairs, pairs1d, pairs2d, pairs1w, pairs2w])
 

--- a/src/pages/analytics/tokens/[id].tsx
+++ b/src/pages/analytics/tokens/[id].tsx
@@ -59,6 +59,7 @@ export default function Token() {
 
   useEffect(() => {
     const fetch = async () => {
+      /* @ts-ignore TYPE NEEDS FIXING */
       setTotalSupply(await tokenContract.totalSupply())
     }
     fetch()
@@ -99,8 +100,11 @@ export default function Token() {
 
   const tokenPairsFormatted = useMemo(
     () =>
+      /* @ts-ignore TYPE NEEDS FIXING */
       tokenPairs?.map((pair) => {
+        /* @ts-ignore TYPE NEEDS FIXING */
         const pair1d = tokenPairs1d?.find((p) => pair.id === p.id) ?? pair
+        /* @ts-ignore TYPE NEEDS FIXING */
         const pair1w = tokenPairs1w?.find((p) => pair.id === p.id) ?? pair1d
 
         return {
@@ -142,11 +146,15 @@ export default function Token() {
   const chartData = useMemo(
     () => ({
       liquidityChart: tokenDayData
+        /* @ts-ignore TYPE NEEDS FIXING */
         ?.sort((a, b) => a.date - b.date)
+        /* @ts-ignore TYPE NEEDS FIXING */
         .map((day) => ({ x: new Date(day.date * 1000), y: Number(day.liquidityUSD) })),
 
       volumeChart: tokenDayData
+        /* @ts-ignore TYPE NEEDS FIXING */
         ?.sort((a, b) => a.date - b.date)
+        /* @ts-ignore TYPE NEEDS FIXING */
         .map((day) => ({ x: new Date(day.date * 1000), y: Number(day.volumeUSD) })),
     }),
     [tokenDayData]
@@ -173,6 +181,7 @@ export default function Token() {
               {'<'} Go Back
             </button>
             <div className="flex items-center space-x-4">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <CurrencyLogo className="rounded-full" currency={currency} size={60} />
               <div>
                 <div className="text-sm font-medium text-secondary">{token?.symbol}</div>
@@ -270,6 +279,7 @@ export default function Token() {
           <div className="text-2xl font-bold text-high-emphesis">Top Pairs</div>
           <PairList pairs={tokenPairsFormatted} type="all" />
         </div>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <LegacyTransactions pairs={tokenPairs ? tokenPairs.map((pair) => pair.id) : []} />
       </div>
     </AnalyticsContainer>

--- a/src/pages/analytics/xsushi.tsx
+++ b/src/pages/analytics/xsushi.tsx
@@ -86,8 +86,11 @@ export default function XSushi() {
   const data = useMemo(
     () =>
       barHistory && dayData && sushiDayData && bar
-        ? barHistory.map((barDay) => {
+        ? // @ts-ignore TYPE NEEDS FIXING
+          barHistory.map((barDay) => {
+            // @ts-ignore TYPE NEEDS FIXING
             const exchangeDay = dayData.find((day) => day.date === barDay.date)
+            //@ts-ignore TYPE NEEDS FIXING
             const sushiDay = sushiDayData.find((day) => day.date === barDay.date)
 
             const totalSushiStakedUSD = barDay.xSushiSupply * barDay.ratio * sushiDay.priceUSD
@@ -112,6 +115,7 @@ export default function XSushi() {
   const APY1d = aprToApy(
     (((exchange?.volumeUSD - exchange1d?.volumeUSD) * 0.0005 * 365.25) / (bar?.totalSupply * xSushiPrice)) * 100 ?? 0
   )
+  // @ts-ignore TYPE NEEDS FIXING
   const APY1w = aprToApy(data.slice(-7).reduce((acc, day) => (acc += day.APY), 0) / 7)
 
   const graphs = useMemo(
@@ -120,10 +124,12 @@ export default function XSushi() {
         title: 'xSushi Performance',
         labels: ['Daily APY', 'Daily APR'],
         data: [
+          // @ts-ignore TYPE NEEDS FIXING
           data.map((d) => ({
             date: d.date * 1000,
             value: d.APY,
           })),
+          // @ts-ignore TYPE NEEDS FIXING
           data.map((d) => ({
             date: d.date * 1000,
             value: d.APR,
@@ -134,6 +140,7 @@ export default function XSushi() {
         title: 'Daily Fees Received',
         labels: ['Fees (USD)'],
         data: [
+          // @ts-ignore TYPE NEEDS FIXING
           data.map((d) => ({
             date: d.date * 1000,
             value: d.feesReceived,
@@ -144,10 +151,12 @@ export default function XSushi() {
         title: 'xSushi Supply Movements',
         labels: ['Daily Minted', 'Daily Burned'],
         data: [
+          // @ts-ignore TYPE NEEDS FIXING
           data.map((d) => ({
             date: d.date * 1000,
             value: d.sushiStaked,
           })),
+          // @ts-ignore TYPE NEEDS FIXING
           data.map((d) => ({
             date: d.date * 1000,
             value: d.sushiHarvested,
@@ -158,6 +167,7 @@ export default function XSushi() {
         title: 'xSushi Total Supply',
         labels: ['Supply'],
         data: [
+          // @ts-ignore TYPE NEEDS FIXING
           data.map((d) => ({
             date: d.date * 1000,
             value: d.xSushiSupply,

--- a/src/pages/api/farms/index.ts
+++ b/src/pages/api/farms/index.ts
@@ -1,5 +1,6 @@
 import { withSentry } from '@sentry/nextjs'
 
+// @ts-ignore TYPE NEEDS FIXING
 const handler = async (req, res) => {
   res.status(200).json([{ id: 1 }, { id: 2 }])
 }

--- a/src/pages/api/pools/constant-product.ts
+++ b/src/pages/api/pools/constant-product.ts
@@ -1,5 +1,6 @@
 import { withSentry } from '@sentry/nextjs'
 
+// @ts-ignore TYPE NEEDS FIXING
 const handler = async (req, res) => {
   res.status(200).json({ name: 'John Doe' })
 }

--- a/src/pages/api/pools/index.ts
+++ b/src/pages/api/pools/index.ts
@@ -1,5 +1,6 @@
 import { withSentry } from '@sentry/nextjs'
 
+// @ts-ignore TYPE NEEDS FIXING
 const handler = async (req, res) => {
   res.status(200).json([{ id: 1 }, { id: 2 }])
 }

--- a/src/pages/api/test.ts
+++ b/src/pages/api/test.ts
@@ -1,5 +1,6 @@
 import { withSentry } from '@sentry/nextjs'
 
+// @ts-ignore TYPE NEEDS FIXING
 const handler = async (req, res) => {
   throw new Error('API throw error test')
 }

--- a/src/pages/api/tines/index.ts
+++ b/src/pages/api/tines/index.ts
@@ -1,5 +1,6 @@
 import { withSentry } from '@sentry/nextjs'
 
+// @ts-ignore TYPE NEEDS FIXING
 const handler = async (req, res) => {
   res.status(200).json([])
 }

--- a/src/pages/api/users/index.ts
+++ b/src/pages/api/users/index.ts
@@ -1,5 +1,6 @@
 import { withSentry } from '@sentry/nextjs'
 
+// @ts-ignore TYPE NEEDS FIXING
 const handler = async (req, res) => {
   res.status(200).json([{ id: 1 }, { id: 2 }])
 }

--- a/src/pages/bar/index.tsx
+++ b/src/pages/bar/index.tsx
@@ -82,10 +82,12 @@ export default function Stake() {
   }
 
   const handleClickMax = () => {
+    // @ts-ignore TYPE NEEDS FIXING
     setInput(parsedAmount ? parsedAmount.toSignificant(balance.currency.decimals).substring(0, INPUT_CHAR_LIMIT) : '')
     setUsingBalance(true)
   }
 
+  // @ts-ignore TYPE NEEDS FIXING
   const insufficientFunds = (balance && balance.equalTo(ZERO)) || parsedAmount?.greaterThan(balance)
 
   const inputError = insufficientFunds

--- a/src/pages/borrow/[pair].tsx
+++ b/src/pages/borrow/[pair].tsx
@@ -34,20 +34,24 @@ export default function Pair() {
   return (
     <PairLayout>
       <Head>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <title>{i18n._(t`Borrow ${pair?.asset?.symbol}-${pair?.collateral?.symbol}`)} | Sushi</title>
         <meta
           key="description"
           name="description"
+          /* @ts-ignore TYPE NEEDS FIXING */
           content={`Borrow ${pair?.asset?.symbol} against ${pair?.collateral?.symbol} collateral on Kashi by Sushi`}
         />
         <meta
           key="twitter:description"
           name="twitter:description"
+          /* @ts-ignore TYPE NEEDS FIXING */
           content={`Borrow ${pair?.asset?.symbol} against ${pair?.collateral?.symbol} collateral on Kashi by Sushi`}
         />
         <meta
           key="og:description"
           property="og:description"
+          /* @ts-ignore TYPE NEEDS FIXING */
           content={`Borrow ${pair?.asset?.symbol} against ${pair?.collateral?.symbol} collateral on Kashi by Sushi`}
         />
       </Head>
@@ -62,16 +66,20 @@ export default function Pair() {
                     <Image
                       height={48}
                       width={48}
+                      /* @ts-ignore TYPE NEEDS FIXING */
                       src={pair.asset.tokenInfo.logoURI}
                       className="block w-10 h-10 rounded-lg sm:w-12 sm:h-12"
+                      /* @ts-ignore TYPE NEEDS FIXING */
                       alt={pair.asset.tokenInfo.symbol}
                     />
 
                     <Image
                       height={48}
                       width={48}
+                      /* @ts-ignore TYPE NEEDS FIXING */
                       src={pair.collateral.tokenInfo.logoURI}
                       className="block w-10 h-10 rounded-lg sm:w-12 sm:h-12"
+                      /* @ts-ignore TYPE NEEDS FIXING */
                       alt={pair.collateral.tokenInfo.symbol}
                     />
                   </>
@@ -79,11 +87,14 @@ export default function Pair() {
               </div>
               <div className="flex items-center justify-between">
                 <div>
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   <div className="text-3xl text-high-emphesis">{i18n._(t`Borrow ${pair.asset.tokenInfo.symbol}`)}</div>
                   <div className="flex items-center">
                     <div className="mr-1 text-sm text-secondary">{i18n._(t`Collateral`)}:</div>
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     <div className="mr-2 text-sm text-high-emphesis">{pair.collateral.tokenInfo.symbol}</div>
                     <div className="mr-1 text-sm text-secondary">{i18n._(t`Oracle`)}:</div>
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     <div className="text-sm text-high-emphesis">{pair.oracle.name}</div>
                   </div>
                 </div>
@@ -96,23 +107,29 @@ export default function Pair() {
           <div>
             <div className="text-lg text-secondary">{i18n._(t`Collateral`)}</div>
             <div className="text-2xl text-blue">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {formatNumber(pair.userCollateralAmount.string)} {pair.collateral.tokenInfo.symbol}
             </div>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             <div className="text-lg text-high-emphesis">{formatNumber(pair.userCollateralAmount.usd, true)}</div>
           </div>
           <div>
             <div className="text-lg text-secondary">{i18n._(t`Borrowed`)}</div>
             <div className="text-2xl text-pink">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {formatNumber(pair.currentUserBorrowAmount.string)} {pair.asset.tokenInfo.symbol}
             </div>
             <div className="flex items-center text-lg text-high-emphesis">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {formatPercent(pair.health.string)}
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <GradientDot percent={pair.health.string}></GradientDot>
             </div>
           </div>
           <div className="text-right">
             <div>
               <div className="text-lg text-secondary">{i18n._(t`APR`)}</div>
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <div className="text-2xl text-high-emphesis">{formatPercent(pair.interestPerYear.string)}</div>
             </div>
           </div>
@@ -152,14 +169,20 @@ export default function Pair() {
 
 Pair.Provider = RecoilRoot
 
+// @ts-ignore TYPE NEEDS FIXING
 const PairLayout = ({ children }) => {
   const { i18n } = useLingui()
   const router = useRouter()
   const pair = useKashiPair(router.query.pair as string)
+  // @ts-ignore TYPE NEEDS FIXING
   const asset = useToken(pair?.asset.address)
+  // @ts-ignore TYPE NEEDS FIXING
   const collateral = useToken(pair?.collateral.address)
+  // @ts-ignore TYPE NEEDS FIXING
   const [pairState, liquidityPair] = useV2Pair(asset, collateral)
+  // @ts-ignore TYPE NEEDS FIXING
   const assetPrice = useUSDCPrice(asset)
+  // @ts-ignore TYPE NEEDS FIXING
   const collateralPrice = useUSDCPrice(collateral)
 
   return pair ? (
@@ -183,6 +206,7 @@ const PairLayout = ({ children }) => {
             <div className="flex justify-between">
               <div className="text-lg text-secondary">{i18n._(t`APR`)}</div>
               <div className="flex items-center">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <div className="text-lg text-high-emphesis">{formatPercent(pair?.currentInterestPerYear.string)}</div>
               </div>
             </div>
@@ -193,6 +217,7 @@ const PairLayout = ({ children }) => {
             <div className="flex justify-between">
               <div className="text-lg text-secondary">{i18n._(t`Total`)}</div>
               <div className="text-lg text-high-emphesis">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {formatNumber(pair?.currentAllAssets.string)} {pair?.asset.tokenInfo.symbol}
               </div>
             </div>
@@ -200,6 +225,7 @@ const PairLayout = ({ children }) => {
               <div className="text-lg text-secondary">{i18n._(t`Available`)}</div>
               <div className="flex items-center">
                 <div className="text-lg text-high-emphesis">
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {formatNumber(pair?.totalAssetAmount.string)} {pair?.asset.tokenInfo.symbol}
                 </div>
               </div>
@@ -207,6 +233,7 @@ const PairLayout = ({ children }) => {
             <div className="flex justify-between">
               <div className="text-lg text-secondary">{i18n._(t`Borrowed`)}</div>
               <div className="flex items-center">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <div className="text-lg text-high-emphesis">{formatPercent(pair?.utilization.string)}</div>
               </div>
             </div>
@@ -219,6 +246,7 @@ const PairLayout = ({ children }) => {
 
             <div className="flex justify-between">
               <div className="text-lg text-secondary">Name</div>
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <div className="text-lg text-high-emphesis">{pair?.oracle.name}</div>
             </div>
 
@@ -226,8 +254,10 @@ const PairLayout = ({ children }) => {
               <div className="text-xl text-high-emphesis">{i18n._(t`BentoBox`)}</div>
             </div>
             <div className="flex justify-between">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <div className="text-lg text-secondary">{i18n._(t`${pair?.collateral.tokenInfo.symbol} Strategy`)}</div>
               <div className="flex flex-row text-lg text-high-emphesis">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {pair.collateral.strategy ? (
                   i18n._(t`Active`)
                 ) : (
@@ -243,8 +273,10 @@ const PairLayout = ({ children }) => {
               </div>
             </div>
 
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             <Strategy token={pair.collateral} />
 
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {pair && pair.oracle.name === 'SushiSwap' && (
               <>
                 <div className="flex justify-between pt-3">
@@ -267,7 +299,9 @@ const PairLayout = ({ children }) => {
                       <div className="text-lg text-high-emphesis">
                         {formatNumber(
                           liquidityPair?.reserve1
+                            // @ts-ignore TYPE NEEDS FIXING
                             .multiply(assetPrice?.quotient)
+                            // @ts-ignore TYPE NEEDS FIXING
                             .add(liquidityPair?.reserve1.multiply(collateralPrice?.quotient))
                             .toSignificant(4),
                           true

--- a/src/pages/borrow/index.tsx
+++ b/src/pages/borrow/index.tsx
@@ -22,6 +22,7 @@ import { RecoilRoot } from 'recoil'
 export default function Borrow() {
   const { i18n } = useLingui()
   const addresses = useKashiPairAddresses()
+  // @ts-ignore TYPE NEEDS FIXING
   const pairs = useKashiPairs(addresses)
 
   const positions = useSearchAndSort(
@@ -298,6 +299,7 @@ export default function Borrow() {
 
 Borrow.Provider = RecoilRoot
 
+// @ts-ignore TYPE NEEDS FIXING
 const BorrowLayout = ({ children }) => {
   const { i18n } = useLingui()
   return (

--- a/src/pages/chains/index.tsx
+++ b/src/pages/chains/index.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 
 const getChains = (url = 'https://chainid.network/chains.json') => fetch(url).then((res) => res.json())
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function Status({ fallbackData }) {
   const res = useSWR('https://chainid.network/chains.json', getChains, { fallbackData })
   const { data } = res
@@ -21,6 +22,7 @@ export default function Status({ fallbackData }) {
           Chains
         </Typography>
         <div className="grid items-start justify-start grid-cols-2 gap-3 mx-auto ">
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           {data.map((chain, key) => {
             return (
               <div key={key} className="h-full p-1 rounded bg-dark-900 text-primary">

--- a/src/pages/farm/index.tsx
+++ b/src/pages/farm/index.tsx
@@ -22,23 +22,31 @@ export default function Farm(): JSX.Element {
   const router = useRouter()
   const type = router.query.filter === null ? 'all' : (router.query.filter as string)
 
+  // @ts-ignore TYPE NEEDS FIXING
   const positions = usePositions(chainId)
 
   const FILTER = {
+    // @ts-ignore TYPE NEEDS FIXING
     all: (farm) => farm.allocPoint !== '0' && farm.chef !== Chef.OLD_FARMS,
+    // @ts-ignore TYPE NEEDS FIXING
     portfolio: (farm) => farm?.amount && !farm.amount.isZero(),
+    // @ts-ignore TYPE NEEDS FIXING
     sushi: (farm) => farm.pair.type === PairType.SWAP && farm.allocPoint !== '0',
+    // @ts-ignore TYPE NEEDS FIXING
     kashi: (farm) => farm.pair.type === PairType.KASHI && farm.allocPoint !== '0',
+    // @ts-ignore TYPE NEEDS FIXING
     '2x': (farm) =>
       (farm.chef === Chef.MASTERCHEF_V2 || farm.chef === Chef.MINICHEF) &&
       farm.rewards.length > 1 &&
       farm.allocPoint !== '0',
+    // @ts-ignore TYPE NEEDS FIXING
     old: (farm) => farm.chef === Chef.OLD_FARMS,
   }
 
   const rewards = useFarmRewards()
 
   const data = rewards.filter((farm) => {
+    // @ts-ignore TYPE NEEDS FIXING
     return type in FILTER ? FILTER[type](farm) : true
   })
 

--- a/src/pages/kashi/create/index.tsx
+++ b/src/pages/kashi/create/index.tsx
@@ -62,6 +62,7 @@ export default function Create() {
     async (asset: Currency, collateral: Currency) => {
       const oracleData = ''
 
+      // @ts-ignore TYPE NEEDS FIXING
       const mapping = CHAINLINK_PRICE_FEED_MAP[chainId]
 
       for (const address in mapping) {
@@ -72,6 +73,7 @@ export default function Create() {
       let divide = AddressZero
 
       const multiplyMatches = Object.values(mapping).filter(
+        // @ts-ignore TYPE NEEDS FIXING
         (m) => m.from === asset.wrapped.address && m.to === collateral.wrapped.address
       )
 
@@ -79,28 +81,39 @@ export default function Create() {
 
       if (multiplyMatches.length) {
         const match = multiplyMatches[0]
+        // @ts-ignore TYPE NEEDS FIXING
         multiply = match.address!
+        // @ts-ignore TYPE NEEDS FIXING
         decimals = 18 + match.decimals - match.toDecimals + match.fromDecimals
       } else {
         const divideMatches = Object.values(mapping).filter(
+          // @ts-ignore TYPE NEEDS FIXING
           (m) => m.from === collateral.wrapped.address && m.to === asset.wrapped.address
         )
         if (divideMatches.length) {
           const match = divideMatches[0]
+          // @ts-ignore TYPE NEEDS FIXING
           divide = match.address!
+          // @ts-ignore TYPE NEEDS FIXING
           decimals = 36 - match.decimals - match.toDecimals + match.fromDecimals
         } else {
+          // @ts-ignore TYPE NEEDS FIXING
           const mapFrom = Object.values(mapping).filter((m) => m.from === asset.wrapped.address)
+          // @ts-ignore TYPE NEEDS FIXING
           const mapTo = Object.values(mapping).filter((m) => m.from === collateral.wrapped.address)
           const match = mapFrom
             .map((mfrom) => ({
               mfrom: mfrom,
+              // @ts-ignore TYPE NEEDS FIXING
               mto: mapTo.filter((mto) => mfrom.to === mto.to),
             }))
             .filter((path) => path.mto.length)
           if (match.length) {
+            // @ts-ignore TYPE NEEDS FIXING
             multiply = match[0].mfrom.address!
+            // @ts-ignore TYPE NEEDS FIXING
             divide = match[0].mto[0].address!
+            // @ts-ignore TYPE NEEDS FIXING
             decimals = 18 + match[0].mfrom.decimals - match[0].mto[0].decimals - collateral.decimals + asset.decimals
           } else {
             return ''
@@ -117,6 +130,7 @@ export default function Create() {
     try {
       if (!both) return
 
+      // @ts-ignore TYPE NEEDS FIXING
       const oracleData = await getOracleData(currencies[Field.ASSET], currencies[Field.COLLATERAL])
 
       if (!oracleData) {
@@ -124,22 +138,27 @@ export default function Create() {
         return
       }
 
+      // @ts-ignore TYPE NEEDS FIXING
       if (!(chainId in CHAINLINK_ORACLE_ADDRESS)) {
         console.log('No chainlink oracle address')
         return
       }
 
+      // @ts-ignore TYPE NEEDS FIXING
       if (!(chainId in KASHI_ADDRESS)) {
         console.log('No kashi address')
         return
       }
 
+      // @ts-ignore TYPE NEEDS FIXING
       const oracleAddress = CHAINLINK_ORACLE_ADDRESS[chainId]
 
       const kashiData = defaultAbiCoder.encode(
         ['address', 'address', 'address', 'bytes'],
         [
+          // @ts-ignore TYPE NEEDS FIXING
           currencies[Field.COLLATERAL].wrapped.address,
+          // @ts-ignore TYPE NEEDS FIXING
           currencies[Field.ASSET].wrapped.address,
           oracleAddress,
           oracleData,
@@ -147,7 +166,9 @@ export default function Create() {
       )
 
       console.log([
+        // @ts-ignore TYPE NEEDS FIXING
         currencies[Field.COLLATERAL].wrapped.address,
+        // @ts-ignore TYPE NEEDS FIXING
         currencies[Field.ASSET].wrapped.address,
         oracleAddress,
         oracleData,
@@ -156,6 +177,7 @@ export default function Create() {
       const tx = await bentoBoxContract?.deploy(chainId && KASHI_ADDRESS[chainId], kashiData, true)
 
       addTransaction(tx, {
+        // @ts-ignore TYPE NEEDS FIXING
         summary: `Add Kashi market ${currencies[Field.ASSET].symbol}/${currencies[Field.COLLATERAL].symbol} Chainlink`,
       })
 
@@ -226,6 +248,7 @@ export default function Create() {
   )
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const CreateLayout = ({ children }) => {
   const { i18n } = useLingui()
   return (

--- a/src/pages/legacy/add/[[...tokens]].tsx
+++ b/src/pages/legacy/add/[[...tokens]].tsx
@@ -221,6 +221,7 @@ export default function Add() {
         <div className="text-2xl font-bold text-high-emphesis">
           {currencies[Field.CURRENCY_A]?.symbol + '/' + currencies[Field.CURRENCY_B]?.symbol}
         </div>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <DoubleCurrencyLogo currency0={currencyA} currency1={currencyB} size={48} />
       </div>
     </div>
@@ -229,6 +230,7 @@ export default function Add() {
       <div className="flex items-center justify-start gap-3">
         <div className="text-xl font-bold md:text-3xl text-high-emphesis">{liquidityMinted?.toSignificant(6)}</div>
         <div className="grid grid-flow-col gap-2">
+          {/*@ts-ignore TYPE NEEDS FIXING*/}
           <DoubleCurrencyLogo currency0={currencyA} currency1={currencyB} size={48} />
         </div>
       </div>

--- a/src/pages/legacy/find/index.tsx
+++ b/src/pages/legacy/find/index.tsx
@@ -32,6 +32,7 @@ export default function PoolFinder() {
 
   const [activeField, setActiveField] = useState<number>(Fields.TOKEN1)
 
+  // @ts-ignore TYPE NEEDS FIXING
   const [currency0, setCurrency0] = useState<Currency | null>(() => (chainId ? NATIVE[chainId] : null))
   const [currency1, setCurrency1] = useState<Currency | null>(null)
 

--- a/src/pages/legacy/limit-order/[[...tokens]].tsx
+++ b/src/pages/legacy/limit-order/[[...tokens]].tsx
@@ -38,6 +38,7 @@ import Lottie from 'lottie-react'
 import Head from 'next/head'
 import React, { useCallback, useMemo, useState } from 'react'
 
+// @ts-ignore TYPE NEEDS FIXING
 const areEqual = (first, second) => {
   if (first.length !== second.length) {
     return false
@@ -62,6 +63,7 @@ function LimitOrder() {
   const { onSwitchTokens, onCurrencySelection, onUserInput, onChangeRecipient } = useLimitOrderActionHandlers()
   const [animateSwapArrows, setAnimateSwapArrows] = useState<boolean>(false)
   const pairs = useMemo(
+    // @ts-ignore TYPE NEEDS FIXING
     () => (limitOrderPairList.pairs[chainId || 1] || []).map(([token0, token1]) => [token0.address, token1.address]),
     [chainId]
   )
@@ -103,6 +105,7 @@ function LimitOrder() {
       pairs &&
       inputCurrency &&
       outputCurrency &&
+      // @ts-ignore TYPE NEEDS FIXING
       !pairs.find((el) => areEqual(el, [inputCurrency.wrapped.address, outputCurrency.wrapped.address]))
     ) {
       return 'Invalid pair'
@@ -111,6 +114,7 @@ function LimitOrder() {
 
   const inputTokenList = useMemo(() => {
     if (pairs.length === 0) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return pairs.reduce((acc, [token0, token1]) => {
       acc.push(token0)
       acc.push(token1)
@@ -121,12 +125,14 @@ function LimitOrder() {
   const outputTokenList = useMemo(() => {
     if (pairs.length === 0) return []
     if (inputCurrency) {
+      // @ts-ignore TYPE NEEDS FIXING
       return pairs.reduce((acc, [token0, token1]) => {
         if (inputCurrency.wrapped.address === token0) acc.push(token1)
         if (inputCurrency.wrapped.address === token1) acc.push(token0)
         return acc
       }, [])
     }
+    // @ts-ignore TYPE NEEDS FIXING
     return pairs.reduce((acc, [token0, token1]) => {
       acc.push(token0)
       acc.push(token1)
@@ -199,6 +205,7 @@ function LimitOrder() {
                     </div>
                   </button>
                 </div>
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <LimitPriceInputPanel trade={trade} />
               </div>
               <CurrencyInputPanel
@@ -263,6 +270,7 @@ function LimitOrder() {
             <div className="flex flex-col items-end justify-between w-full gap-4 md:flex-row md:items-center">
               {inputCurrency && outputCurrency && (
                 <div className="flex flex-1">
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   <PriceRatio trade={trade} />
                 </div>
               )}

--- a/src/pages/legacy/migrate/index.tsx
+++ b/src/pages/legacy/migrate/index.tsx
@@ -209,6 +209,7 @@ const MigrateButtons = ({ state, exchange }: { state: MigrateState; exchange: st
       await state.onMigrate()
     } catch (error) {
       console.log(error)
+      // @ts-ignore TYPE NEEDS FIXING
       setError(error)
     }
   }

--- a/src/pages/legacy/pool/index.tsx
+++ b/src/pages/legacy/pool/index.tsx
@@ -40,6 +40,7 @@ export default function Pool() {
   //       .filter((stakingPair) => stakingPair?.liquidityToken.address === v2Pair.liquidityToken.address).length === 0
   //   )
   // })
+  // @ts-ignore TYPE NEEDS FIXING
   const migrationSupported = chainId in MigrationSupported
   return (
     <Container id="pool-page" className="py-4 space-y-6 md:py-8 lg:py-12" maxWidth="2xl">
@@ -114,6 +115,7 @@ export default function Pool() {
                 id="add-pool-button"
                 color="gradient"
                 className="grid items-center justify-center grid-flow-col gap-2 whitespace-nowrap"
+                // @ts-ignore TYPE NEEDS FIXING
                 onClick={() => router.push(`/add/${currencyId(NATIVE[chainId])}`)}
               >
                 {i18n._(t`Add`)}

--- a/src/pages/legacy/remove/[[...tokens]].tsx
+++ b/src/pages/legacy/remove/[[...tokens]].tsx
@@ -110,6 +110,7 @@ export default function Remove() {
         await gatherPermitSignature()
       } catch (error) {
         // try to approve if gatherPermitSignature failed for any reason other than the user rejecting it
+        /* @ts-ignore TYPE NEEDS FIXING */
         if (error?.code !== 4001) {
           await approveCallback()
         }
@@ -234,6 +235,7 @@ export default function Remove() {
 
     const safeGasEstimates: (BigNumber | undefined)[] = await Promise.all(
       methodNames.map((methodName) =>
+        /* @ts-ignore TYPE NEEDS FIXING */
         routerContract.estimateGas[methodName](...args)
           .then(calculateGasMargin)
           .catch((error) => {
@@ -255,6 +257,7 @@ export default function Remove() {
       const safeGasEstimate = safeGasEstimates[indexOfSuccessfulEstimation]
 
       setAttemptingTxn(true)
+      /* @ts-ignore TYPE NEEDS FIXING */
       await routerContract[methodName](...args, {
         gasLimit: safeGasEstimate,
       })
@@ -497,6 +500,7 @@ export default function Remove() {
                                 }`}
                               >
                                 <a className="text-baseline text-blue opacity-80 hover:opacity-100 focus:opacity-100 whitespace-nowrap">
+                                  {/* @ts-ignore TYPE NEEDS FIXING */}
                                   Receive W{NATIVE[chainId].symbol}
                                 </a>
                               </Link>
@@ -507,6 +511,7 @@ export default function Remove() {
                                 }`}
                               >
                                 <a className="text-baseline text-blue opacity-80 hover:opacity-100 whitespace-nowrap">
+                                  {/* @ts-ignore TYPE NEEDS FIXING */}
                                   Receive {NATIVE[chainId].symbol}
                                 </a>
                               </Link>

--- a/src/pages/legacy/swap/[[...tokens]].tsx
+++ b/src/pages/legacy/swap/[[...tokens]].tsx
@@ -56,6 +56,7 @@ export async function getServerSideProps() {
   }
 }
 
+/* @ts-ignore TYPE NEEDS FIXING */
 export default function Swap({ banners }) {
   const { i18n } = useLingui()
 
@@ -183,11 +184,13 @@ export default function Swap({ banners }) {
   const formattedAmounts = {
     [independentField]: typedValue,
     [dependentField]: showWrap
-      ? parsedAmounts[independentField]?.toExact() ?? ''
+      ? /* @ts-ignore TYPE NEEDS FIXING */
+        parsedAmounts[independentField]?.toExact() ?? ''
       : parsedAmounts[dependentField]?.toSignificant(6) ?? '',
   }
 
   const userHasSpecifiedInputOutput = Boolean(
+    /* @ts-ignore TYPE NEEDS FIXING */
     currencies[Field.INPUT] && currencies[Field.OUTPUT] && parsedAmounts[independentField]?.greaterThan(JSBI.BigInt(0))
   )
 
@@ -242,6 +245,7 @@ export default function Swap({ banners }) {
     allowedSlippage,
     recipient,
     signatureData,
+    /* @ts-ignore TYPE NEEDS FIXING */
     null,
     useOpenMev
   )

--- a/src/pages/lend/[pair].tsx
+++ b/src/pages/lend/[pair].tsx
@@ -29,13 +29,17 @@ export default function Pair() {
   return (
     <PairLayout>
       <Head>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <title>Lend {pair.asset.tokenInfo.symbol} | Sushi</title>
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <meta key="description" name="description" content={`Lend ${pair.asset.tokenInfo.symbol} on Kashi`} />
         <meta
           key="twitter:description"
           name="twitter:description"
+          /*@ts-ignore TYPE NEEDS FIXING*/
           content={`Lend ${pair.asset.tokenInfo.symbol} on Kashi`}
         />
+        {/*@ts-ignore TYPE NEEDS FIXING*/}
         <meta key="og:description" property="og:description" content={`Lend ${pair.asset.tokenInfo.symbol} on Kashi`} />
       </Head>
       <Card
@@ -49,15 +53,19 @@ export default function Pair() {
                     <Image
                       height={48}
                       width={48}
+                      // @ts-ignore TYPE NEEDS FIXING
                       src={pair.asset.tokenInfo.logoURI}
                       className="w-10 h-10 rounded-lg sm:w-12 sm:h-12"
+                      // @ts-ignore TYPE NEEDS FIXING
                       alt={pair.asset.tokenInfo.symbol}
                     />
                     <Image
                       height={48}
                       width={48}
+                      // @ts-ignore TYPE NEEDS FIXING
                       src={pair.collateral.tokenInfo.logoURI}
                       className="w-10 h-10 rounded-lg sm:w-12 sm:h-12"
+                      // @ts-ignore TYPE NEEDS FIXING
                       alt={pair.collateral.tokenInfo.symbol}
                     />
                   </>
@@ -66,12 +74,15 @@ export default function Pair() {
               <div className="flex items-center justify-between">
                 <div>
                   <div className="text-3xl text-high-emphesis">
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     {i18n._(t`Lend`)} {pair && pair.asset.tokenInfo.symbol}
                   </div>
                   <div className="flex items-center">
                     <div className="mr-1 text-sm text-secondary">{i18n._(t`Collateral`)}:</div>
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     <div className="mr-2 text-sm text-high-emphesis">{pair && pair.collateral.tokenInfo.symbol}</div>
                     <div className="mr-1 text-sm text-secondary">{i18n._(t`Oracle`)}:</div>
+                    {/*@ts-ignore TYPE NEEDS FIXING*/}
                     <div className="text-sm text-high-emphesis">{pair && pair.oracle.name}</div>
                   </div>
                 </div>
@@ -84,17 +95,21 @@ export default function Pair() {
           <div>
             <div className="text-lg text-secondary">Lent</div>
             <div className="text-2xl text-blue">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {formatNumber(pair.currentUserAssetAmount.string)} {pair.asset.tokenInfo.symbol}
             </div>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             <div className="text-lg text-high-emphesis">{formatNumber(pair.currentUserAssetAmount.usd, true)}</div>
           </div>
           <div>
             <div className="text-lg text-secondary">{i18n._(t`Borrowed`)}</div>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             <div className="text-2xl text-high-emphesis">{formatPercent(pair.utilization.string)}</div>
           </div>
           <div className="text-right">
             <div>
               <div className="text-lg text-secondary">{i18n._(t`Supply APR`)}</div>
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <div className="text-2xl text-high-emphesis">{formatPercent(pair.supplyAPR.string)}</div>
             </div>
           </div>
@@ -109,6 +124,7 @@ export default function Pair() {
                 } flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none`
               }
             >
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {i18n._(t`Deposit`)} {pair.asset.tokenInfo.symbol}
             </Tab>
             <Tab
@@ -118,6 +134,7 @@ export default function Pair() {
                 } flex items-center justify-center flex-1 px-3 py-4 text-lg rounded cursor-pointer select-none text-secondary hover:text-primary focus:outline-none`
               }
             >
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               {i18n._(t`Withdraw`)} {pair.asset.tokenInfo.symbol}
             </Tab>
           </Tab.List>
@@ -135,6 +152,7 @@ export default function Pair() {
 
 Pair.Provider = RecoilRoot
 
+// @ts-ignore TYPE NEEDS FIXING
 const PairLayout = ({ children }) => {
   const router = useRouter()
   const { i18n } = useLingui()
@@ -161,6 +179,7 @@ const PairLayout = ({ children }) => {
             <div className="flex justify-between">
               <div className="text-lg text-secondary">{i18n._(t`APR`)}</div>
               <div className="flex items-center">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <div className="text-lg text-high-emphesis">{formatPercent(pair?.currentSupplyAPR.string)}</div>
               </div>
             </div>
@@ -168,18 +187,21 @@ const PairLayout = ({ children }) => {
             <div className="flex justify-between">
               <div className="text-lg text-secondary">{i18n._(t`Total`)}</div>
               <div className="text-lg text-high-emphesis">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {formatNumber(pair?.currentAllAssets.string)} {pair?.asset.tokenInfo.symbol}
               </div>
             </div>
             <div className="flex justify-between">
               <div className="text-lg text-secondary">{i18n._(t`Available`)}</div>
               <div className="text-lg text-high-emphesis">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {formatNumber(pair?.totalAssetAmount.string)} {pair?.asset.tokenInfo.symbol}
               </div>
             </div>
             <div className="flex justify-between">
               <div className="text-lg text-secondary">{i18n._(t`Borrowed`)}</div>
               <div className="flex items-center">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 <div className="text-lg text-high-emphesis">{formatPercent(pair?.utilization.string)}</div>
               </div>
             </div>
@@ -187,14 +209,17 @@ const PairLayout = ({ children }) => {
               <div className="text-lg text-secondary">{i18n._(t`Collateral`)}</div>
               <div className="flex items-center">
                 <div className="text-lg text-high-emphesis">
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   {formatNumber(pair?.totalCollateralAmount.string)} {pair?.collateral.tokenInfo.symbol}
                 </div>
               </div>
             </div>
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             {pair?.utilization.value.gt(0) && (
               <div className="flex justify-between">
                 <div className="text-lg text-secondary">{i18n._(t`Health`)}</div>
                 <div className="flex items-center">
+                  {/*@ts-ignore TYPE NEEDS FIXING*/}
                   <div className="text-lg text-high-emphesis">{formatPercent(pair?.marketHealth.toFixed(16))}</div>
                 </div>
               </div>
@@ -208,6 +233,7 @@ const PairLayout = ({ children }) => {
 
             <div className="flex justify-between">
               <div className="text-lg text-secondary">Name</div>
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <div className="text-lg text-high-emphesis">{pair?.oracle.name}</div>
             </div>
 
@@ -215,8 +241,10 @@ const PairLayout = ({ children }) => {
               <div className="text-xl text-high-emphesis">{i18n._(t`BentoBox`)}</div>
             </div>
             <div className="flex justify-between">
+              {/*@ts-ignore TYPE NEEDS FIXING*/}
               <div className="text-lg text-secondary">{i18n._(t`${pair?.asset.tokenInfo.symbol} Strategy`)}</div>
               <div className="flex flex-row text-lg text-high-emphesis">
+                {/*@ts-ignore TYPE NEEDS FIXING*/}
                 {pair.asset.strategy ? (
                   i18n._(t`Active`)
                 ) : (
@@ -232,6 +260,7 @@ const PairLayout = ({ children }) => {
               </div>
             </div>
 
+            {/*@ts-ignore TYPE NEEDS FIXING*/}
             <Strategy token={pair.asset} />
           </div>
         </Card>

--- a/src/pages/lend/index.tsx
+++ b/src/pages/lend/index.tsx
@@ -23,9 +23,12 @@ export default function Lend() {
   const { i18n } = useLingui()
 
   const addresses = useKashiPairAddresses()
+
+  // @ts-ignore TYPE NEEDS FIXING
   const pairs = useKashiPairs(addresses)
 
   const positions = useSearchAndSort(
+    // @ts-ignore TYPE NEEDS FIXING
     pairs.filter((pair) => pair.userAssetFraction.gt(0)),
     { keys: ['search'], threshold: 0.1 },
     { key: 'currentUserAssetAmount.usdValue', direction: 'descending' }
@@ -173,6 +176,7 @@ export default function Lend() {
   )
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const LendEntry = ({ pair, userPosition = false }) => {
   return (
     <Link href={'/lend/' + pair.address}>
@@ -242,6 +246,7 @@ const LendEntry = ({ pair, userPosition = false }) => {
 
 Lend.Provider = RecoilRoot
 
+// @ts-ignore TYPE NEEDS FIXING
 const LendLayout = ({ children }) => {
   const { i18n } = useLingui()
   return (

--- a/src/pages/miso/index.tsx
+++ b/src/pages/miso/index.tsx
@@ -20,6 +20,7 @@ const queryToAuctionStatus = {
 const Miso = () => {
   const { i18n } = useLingui()
   const { query } = useRouter()
+  // @ts-ignore TYPE NEEDS FIXING
   const auctions = useAuctions(queryToAuctionStatus[query?.status as string] ?? AuctionStatus.LIVE)
 
   const tabs = [
@@ -67,6 +68,7 @@ const Miso = () => {
                     <Typography
                       weight={700}
                       className={classNames(
+                        // @ts-ignore TYPE NEEDS FIXING
                         tab.key === (queryToAuctionStatus[query?.status as string] || AuctionStatus.LIVE)
                           ? 'bg-gradient-to-r from-red to-pink bg-clip-text text-transparent'
                           : '',
@@ -77,6 +79,7 @@ const Miso = () => {
                     </Typography>
                     <div
                       className={classNames(
+                        // @ts-ignore TYPE NEEDS FIXING
                         tab.key === queryToAuctionStatus[query?.status as string]
                           ? 'relative bg-gradient-to-r from-red to-pink h-[3px] w-full'
                           : ''

--- a/src/pages/status/index.tsx
+++ b/src/pages/status/index.tsx
@@ -1,6 +1,7 @@
 import Container from 'app/components/Container'
 import Head from 'next/head'
 
+// @ts-ignore TYPE NEEDS FIXING
 export default function Status({ initialData }) {
   //   const res = useChainsStatus({ initialData })
   //   const { data } = res.data

--- a/src/pages/tools/meowshi.tsx
+++ b/src/pages/tools/meowshi.tsx
@@ -112,6 +112,7 @@ export default function Meowshi() {
   }, [fields.independentField, handleInput])
 
   const switchCurrencies = useCallback(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     setCurrencies((prevState) => ({
       [Field.INPUT]: prevState[Field.OUTPUT],
       [Field.OUTPUT]: prevState[Field.INPUT],
@@ -120,6 +121,7 @@ export default function Meowshi() {
 
   const meowshiState = useMemo<MeowshiState>(
     () => ({
+      // @ts-ignore TYPE NEEDS FIXING
       currencies,
       setCurrency,
       switchCurrencies,

--- a/src/pages/trident/swap/index.tsx
+++ b/src/pages/trident/swap/index.tsx
@@ -85,6 +85,7 @@ const Swap = () => {
       value = ''
       typedField = TypedField.A
     } catch (e) {
+      // @ts-ignore TYPE NEEDS FIXING
       error = e.message
     }
 

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -50,6 +50,7 @@ export default function Me() {
 
   const { data, error }: SWRResponse<any, Error> = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/address/${account}/stacks/sushiswap/acts/?&key=ckey_cba3674f2ce5450f9d5dd290589&swaps=true&quote-currency=usd`,
+    // @ts-ignore TYPE NEEDS FIXING
     (url) =>
       fetch(url)
         .then((r) => r.json())

--- a/src/services/covalent/fetchers.ts
+++ b/src/services/covalent/fetchers.ts
@@ -7,45 +7,59 @@ const fetcher = (url: string) =>
     .then((res) => res.json())
     .then((data) => data.data)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTokenBalances = (chainId = ChainId.ETHEREUM, address) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/address/${address}/balances_v2/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getPortfolio = (chainId = ChainId.ETHEREUM, address) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/address/${address}/portfolio_v2/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTransfers = (chainId = ChainId.ETHEREUM, address) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/address/${address}/transfers_v2/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getBlock = (chainId = ChainId.ETHEREUM, blockHeight) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/block_v2/${blockHeight}/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getBlockHeights = (chainId = ChainId.ETHEREUM, startDate, endDate) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/block_v2/${startDate}/${endDate}/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getLogs = (chainId = ChainId.ETHEREUM, address) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/events/address/${address}/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getLogsForTopic = (chainId = ChainId.ETHEREUM, topic) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/events/topics/${topic}/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getNftMetadata = (chainId = ChainId.ETHEREUM, address, tokenId) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/tokens/${address}/nft_metadata/${tokenId}/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getNftTokenIds = (chainId = ChainId.ETHEREUM, address) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/tokens/${address}/nft_token_ids/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getNftTransactions = (chainId = ChainId.ETHEREUM, address, tokenId) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/tokens/${address}/nft_transactions/${tokenId}/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getHoldersChanges = (chainId = ChainId.ETHEREUM, address) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/tokens/${address}/token_holders_changes/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTokenHolders = (chainId = ChainId.ETHEREUM, address) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/tokens/${address}/token_holders/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTokenMetadata = (chainId = ChainId.ETHEREUM, id) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/tokens/tokenlists/${id}/`)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTransaction = (chainId = ChainId.ETHEREUM, txHash) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/trasaction_v2/${txHash}/`)
 
@@ -55,5 +69,6 @@ export const getChainsStatus = () =>
   fetcher(`https://api.covalenthq.com/v1/chains/status/?key=ckey_cba3674f2ce5450f9d5dd290589`)
 
 // TODO: CLASS B
+// @ts-ignore TYPE NEEDS FIXING
 export const getSushiSwapLiquidityTransactions = (chainId = ChainId.ETHEREUM, address) =>
   fetcher(`https://api.covalenthq.com/v1/${chainId}/address/${address}/stacks/sushiswap/acts/`)

--- a/src/services/covalent/hooks.ts
+++ b/src/services/covalent/hooks.ts
@@ -20,6 +20,7 @@ import {
 import useSWR from 'swr'
 
 // CLASS A
+// @ts-ignore TYPE NEEDS FIXING
 export function useTokenBalances({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/address/${address}/balances_v2/`,
@@ -29,6 +30,7 @@ export function useTokenBalances({ fallbackData = undefined, chainId = ChainId.E
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function usePortfolio({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/add{ data }s/${address}/portfolio_v2/`,
@@ -38,6 +40,7 @@ export function usePortfolio({ fallbackData = undefined, chainId = ChainId.ETHER
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useTransfers({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/address/${address}/transfers_v2/`,
@@ -47,6 +50,7 @@ export function useTransfers({ fallbackData = undefined, chainId = ChainId.ETHER
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useBlock({ fallbackData = undefined, chainId = ChainId.ETHEREUM, blockHeight }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/block_v2/${blockHeight}/`,
@@ -56,6 +60,7 @@ export function useBlock({ fallbackData = undefined, chainId = ChainId.ETHEREUM,
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useBlockHeights({ fallbackData = undefined, chainId = ChainId.ETHEREUM, startDate, endDate }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/block_v2/${startDate}/${endDate}/`,
@@ -65,6 +70,7 @@ export function useBlockHeights({ fallbackData = undefined, chainId = ChainId.ET
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useLogs({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/events/address/${address}/`,
@@ -74,6 +80,7 @@ export function useLogs({ fallbackData = undefined, chainId = ChainId.ETHEREUM, 
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useLogsForTopic({ fallbackData = undefined, chainId = ChainId.ETHEREUM, topic }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/events/topics/${topic}/`,
@@ -83,6 +90,7 @@ export function useLogsForTopic({ fallbackData = undefined, chainId = ChainId.ET
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useNftMetadata({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address, tokenId }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/tokens/${address}/nft_metadata/${tokenId}/`,
@@ -92,6 +100,7 @@ export function useNftMetadata({ fallbackData = undefined, chainId = ChainId.ETH
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useNftTokenIds({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/tokens/${address}/nft_token_ids/`,
@@ -101,6 +110,7 @@ export function useNftTokenIds({ fallbackData = undefined, chainId = ChainId.ETH
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useNftTransactions({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address, tokenId }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/tokens/${address}/nft_transactions/${tokenId}/`,
@@ -110,6 +120,7 @@ export function useNftTransactions({ fallbackData = undefined, chainId = ChainId
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useHoldersChanges({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/tokens/${address}/token_holders_changes/`,
@@ -119,6 +130,7 @@ export function useHoldersChanges({ fallbackData = undefined, chainId = ChainId.
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useHolders({ fallbackData = undefined, chainId = ChainId.ETHEREUM, address }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/tokens/${address}/token_holders/`,
@@ -128,6 +140,7 @@ export function useHolders({ fallbackData = undefined, chainId = ChainId.ETHEREU
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useTokenMetadata({ fallbackData = undefined, chainId = ChainId.ETHEREUM, id }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/tokens/tokenlists/${id}/`,
@@ -137,6 +150,7 @@ export function useTokenMetadata({ fallbackData = undefined, chainId = ChainId.E
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useTransaction({ fallbackData = undefined, chainId = ChainId.ETHEREUM, txHash }) {
   const { data } = useSWR(
     `https://api.covalenthq.com/v1/${chainId}/trasaction_v2/${txHash}/`,

--- a/src/services/graph/fetchers/bar.ts
+++ b/src/services/graph/fetchers/bar.ts
@@ -7,6 +7,7 @@ const BAR = {
   [ChainId.ETHEREUM]: 'matthewlilley/bar',
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const fetcher = async (query, variables = undefined) =>
   request(`${GRAPH_HOST[ChainId.ETHEREUM]}/subgraphs/name/${BAR[ChainId.ETHEREUM]}`, query, variables)
 

--- a/src/services/graph/fetchers/bentobox.ts
+++ b/src/services/graph/fetchers/bentobox.ts
@@ -22,7 +22,10 @@ export const BENTOBOX = {
   [ChainId.BSC]: 'sushiswap/bsc-bentobox',
   [ChainId.ARBITRUM]: 'sushiswap/arbitrum-bentobox',
 }
+
+// @ts-ignore TYPE NEEDS FIXING
 const fetcher = async (chainId = ChainId.ETHEREUM, query, variables = undefined) =>
+  // @ts-ignore TYPE NEEDS FIXING
   pager(`${GRAPH_HOST[chainId]}/subgraphs/name/${BENTOBOX[chainId]}`, query, variables)
 
 export const getClones = async (chainId = ChainId.ETHEREUM) => {
@@ -36,20 +39,23 @@ export const getKashiPairs = async (chainId = ChainId.ETHEREUM, variables = unde
   const tokens = await getTokenSubset(chainId, {
     tokenAddresses: Array.from(
       kashiPairs.reduce(
+        // @ts-ignore TYPE NEEDS FIXING
         (previousValue, currentValue) => previousValue.add(currentValue.asset.id, currentValue.collateral.id),
         new Set() // use set to avoid duplicates
       )
     ),
   })
-
+  // @ts-ignore TYPE NEEDS FIXING
   return kashiPairs.map((pair) => ({
     ...pair,
     token0: {
       ...pair.asset,
+      // @ts-ignore TYPE NEEDS FIXING
       ...tokens.find((token) => token.id === pair.asset.id),
     },
     token1: {
       ...pair.collateral,
+      // @ts-ignore TYPE NEEDS FIXING
       ...tokens.find((token) => token.id === pair.collateral.id),
     },
     assetAmount: Math.floor(pair.totalAssetBase / getFraction({ ...pair, token0: pair.asset })).toString(),
@@ -70,9 +76,11 @@ export const getKashiPairs = async (chainId = ChainId.ETHEREUM, variables = unde
   }))
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getUserKashiPairs = async (chainId = ChainId.ETHEREUM, variables) => {
   const { userKashiPairs } = await fetcher(chainId, kashiUserPairsQuery, variables)
 
+  // @ts-ignore TYPE NEEDS FIXING
   return userKashiPairs.map((userPair) => ({
     ...userPair,
     assetAmount: Math.floor(
@@ -95,8 +103,10 @@ export const getUserKashiPairs = async (chainId = ChainId.ETHEREUM, variables) =
   }))
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getBentoUserTokens = async (chainId = ChainId.ETHEREUM, variables): Promise<CurrencyAmount<Token>[]> => {
   const { userTokens } = await fetcher(chainId, bentoUserTokensQuery, variables)
+  // @ts-ignore TYPE NEEDS FIXING
   return userTokens.map(({ share, token: { decimals, id, name, symbol, totalSupplyElastic, totalSupplyBase } }) => {
     return toAmountCurrencyAmount(
       {
@@ -108,18 +118,22 @@ export const getBentoUserTokens = async (chainId = ChainId.ETHEREUM, variables):
   })
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getBentoBox = async (chainId = ChainId.ETHEREUM, variables) => {
   const { bentoBoxes } = await fetcher(chainId, bentoBoxQuery, variables)
 
   return bentoBoxes[0]
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getBentoStrategies = async (chainId = ChainId.ETHEREUM, variables) => {
   const { strategies } = await fetcher(chainId, bentoStrategiesQuery, variables)
 
   const SECONDS_IN_YEAR = 60 * 60 * 24 * 365
 
+  // @ts-ignore TYPE NEEDS FIXING
   return strategies?.map((strategy) => {
+    // @ts-ignore TYPE NEEDS FIXING
     const apys = strategy.harvests?.reduce((apys, _, i) => {
       const [lastHarvest, previousHarvest] = [strategy.harvests?.[i], strategy.harvests?.[i + 1]]
 
@@ -137,6 +151,7 @@ export const getBentoStrategies = async (chainId = ChainId.ETHEREUM, variables) 
       return [...apys, ((profitPerYear / ((tvl + tvlPrevious) / 2)) * 100) / 2]
     }, [])
 
+    // @ts-ignore TYPE NEEDS FIXING
     const apy = apys.reduce((apyAcc, apy) => apyAcc + apy, 0) / apys.length
 
     return {
@@ -148,6 +163,7 @@ export const getBentoStrategies = async (chainId = ChainId.ETHEREUM, variables) 
   })
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getBentoTokens = async (chainId = ChainId.ETHEREUM, variables) => {
   const { tokens } = await fetcher(chainId, bentoTokensQuery, variables)
 

--- a/src/services/graph/fetchers/blocks.ts
+++ b/src/services/graph/fetchers/blocks.ts
@@ -21,25 +21,32 @@ export const BLOCKS = {
   [ChainId.KOVAN]: 'blocklytics/kovan-blocks',
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const fetcher = async (chainId = ChainId.ETHEREUM, query, variables = undefined) => {
+  // @ts-ignore TYPE NEEDS FIXING
   return request(`${GRAPH_HOST[chainId]}/subgraphs/name/${BLOCKS[chainId]}`, query, variables)
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getBlock = async (chainId = ChainId.ETHEREUM, variables) => {
   const { blocks } = await fetcher(chainId, blockQuery, variables)
 
   return { number: Number(blocks?.[0]?.number) }
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getBlocks = async (chainId = ChainId.ETHEREUM, variables) => {
   const { blocks } = await fetcher(chainId, blocksQuery, variables)
   return blocks
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getMassBlocks = async (chainId = ChainId.ETHEREUM, timestamps) => {
   const data = await fetcher(chainId, massBlocksQuery(timestamps))
   return Object.values(data).map((entry) => ({
+    // @ts-ignore TYPE NEEDS FIXING
     number: Number(entry[0].number),
+    // @ts-ignore TYPE NEEDS FIXING
     timestamp: Number(entry[0].timestamp),
   }))
 }
@@ -57,6 +64,7 @@ export const getAverageBlockTime = async (chainId = ChainId.ETHEREUM) => {
   })
 
   const averageBlockTime = blocks?.reduce(
+    // @ts-ignore TYPE NEEDS FIXING
     (previousValue, currentValue, currentIndex) => {
       if (previousValue.timestamp) {
         const difference = previousValue.timestamp - currentValue.timestamp

--- a/src/services/graph/fetchers/exchange.ts
+++ b/src/services/graph/fetchers/exchange.ts
@@ -34,7 +34,9 @@ export const EXCHANGE = {
   [ChainId.FUSE]: 'sushiswap/fuse-exchange',
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const exchange = async (chainId = ChainId.ETHEREUM, query, variables = {}) =>
+  // @ts-ignore TYPE NEEDS FIXING
   pager(`${GRAPH_HOST[chainId]}/subgraphs/name/${EXCHANGE[chainId]}`, query, variables)
 
 export const getPairs = async (chainId = ChainId.ETHEREUM, variables = undefined, query = pairsQuery) => {
@@ -42,42 +44,50 @@ export const getPairs = async (chainId = ChainId.ETHEREUM, variables = undefined
   return pairs
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getPairDayData = async (chainId = ChainId.ETHEREUM, variables) => {
   // console.log('getTokens')
   const { pairDayDatas } = await exchange(chainId, pairDayDatasQuery, variables)
   return pairDayDatas
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTokenSubset = async (chainId = ChainId.ETHEREUM, variables) => {
   // console.log('getTokenSubset')
   const { tokens } = await exchange(chainId, tokenSubsetQuery, variables)
   return tokens
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTokens = async (chainId = ChainId.ETHEREUM, variables) => {
   // console.log('getTokens')
   const { tokens } = await exchange(chainId, tokensQuery, variables)
   return tokens
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getToken = async (chainId = ChainId.ETHEREUM, query = tokenQuery, variables) => {
   // console.log('getTokens')
   const { token } = await exchange(chainId, query, variables)
   return token
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTokenDayData = async (chainId = ChainId.ETHEREUM, variables) => {
   // console.log('getTokens')
   const { tokenDayDatas } = await exchange(chainId, tokenDayDatasQuery, variables)
   return tokenDayDatas
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTokenPrices = async (chainId = ChainId.ETHEREUM, variables) => {
   // console.log('getTokenPrice')
   const { tokens } = await exchange(chainId, tokensQuery, variables)
+  // @ts-ignore TYPE NEEDS FIXING
   return tokens.map((token) => token?.derivedETH)
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTokenPrice = async (chainId = ChainId.ETHEREUM, query, variables) => {
   // console.log('getTokenPrice')
   const nativePrice = await getNativePrice(chainId)
@@ -182,6 +192,7 @@ export const getCeloPrice = async () => {
   })
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getOhmPrice = async (chainId) => {
   if (chainId === ChainId.ARBITRUM) {
     return getTokenPrice(ChainId.ARBITRUM, tokenPriceQuery, {
@@ -228,6 +239,7 @@ export const getBundle = async (
   return exchange(chainId, query, variables)
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getLiquidityPositions = async (chainId = ChainId.ETHEREUM, variables) => {
   const { liquidityPositions } = await exchange(chainId, liquidityPositionsQuery, variables)
   return liquidityPositions

--- a/src/services/graph/fetchers/masterchef.ts
+++ b/src/services/graph/fetchers/masterchef.ts
@@ -27,24 +27,32 @@ export const OLD_MINICHEF = {
   [ChainId.CELO]: 'sushiswap/celo-minichef',
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const miniChef = async (query, chainId = ChainId.ETHEREUM, variables = undefined) =>
+  // @ts-ignore TYPE NEEDS FIXING
   request(`${GRAPH_HOST[chainId]}/subgraphs/name/${MINICHEF[chainId]}`, query, variables)
 
+// @ts-ignore TYPE NEEDS FIXING
 export const oldMiniChef = async (query, chainId = ChainId.ETHEREUM) =>
+  // @ts-ignore TYPE NEEDS FIXING
   request(`${GRAPH_HOST[chainId]}/subgraphs/name/${OLD_MINICHEF[chainId]}`, query)
 
 export const MASTERCHEF_V2 = {
   [ChainId.ETHEREUM]: 'sushiswap/master-chefv2',
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const masterChefV2 = async (query, chainId = ChainId.ETHEREUM, variables = undefined) =>
+  // @ts-ignore TYPE NEEDS FIXING
   request(`${GRAPH_HOST[chainId]}/subgraphs/name/${MASTERCHEF_V2[chainId]}`, query, variables)
 
 export const MASTERCHEF_V1 = {
   [ChainId.ETHEREUM]: 'sushiswap/master-chef',
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const masterChefV1 = async (query, chainId = ChainId.ETHEREUM, variables = undefined) =>
+  // @ts-ignore TYPE NEEDS FIXING
   request(`${GRAPH_HOST[chainId]}/subgraphs/name/${MASTERCHEF_V1[chainId]}`, query, variables)
 
 export const getMasterChefV1TotalAllocPoint = async () => {
@@ -75,12 +83,15 @@ export const getMasterChefV2Farms = async (variables = undefined) => {
   const { pools } = await masterChefV2(poolsV2Query, undefined, variables)
 
   const tokens = await getTokenSubset(ChainId.ETHEREUM, {
+    // @ts-ignore TYPE NEEDS FIXING
     tokenAddresses: Array.from(pools.map((pool) => pool.rewarder.rewardToken)),
   })
 
+  // @ts-ignore TYPE NEEDS FIXING
   return pools.map((pool) => ({
     ...pool,
     rewardToken: {
+      // @ts-ignore TYPE NEEDS FIXING
       ...tokens.find((token) => token.id === pool.rewarder.rewardToken),
     },
   }))

--- a/src/services/graph/fetchers/pager.ts
+++ b/src/services/graph/fetchers/pager.ts
@@ -1,5 +1,6 @@
 import { request } from 'graphql-request'
 
+// @ts-ignore TYPE NEEDS FIXING
 export async function pager(endpoint, query, variables = {}) {
   if (endpoint.includes('undefined')) return {}
 
@@ -19,6 +20,7 @@ export async function pager(endpoint, query, variables = {}) {
       if (entry.length === 1000) flag = true
     })
 
+    // @ts-ignore TYPE NEEDS FIXING
     if (Object.keys(variables).includes('first') && variables['first'] !== undefined) break
 
     skip += 1000

--- a/src/services/graph/fetchers/pools.ts
+++ b/src/services/graph/fetchers/pools.ts
@@ -12,7 +12,9 @@ import {
 
 import { pager } from './pager'
 
+// @ts-ignore TYPE NEEDS FIXING
 export const fetcher = async (chainId = ChainId.ETHEREUM, query, variables = undefined) =>
+  // @ts-ignore TYPE NEEDS FIXING
   pager(`${GRAPH_HOST[chainId]}/subgraphs/name/${TRIDENT[chainId]}`, query, variables)
 
 const gqlPoolTypeMap: Record<string, PoolType> = {
@@ -83,8 +85,10 @@ interface TridentPoolQueryResult {
 
 export const getTridentPools = async (
   chainId: ChainId = ChainId.ETHEREUM,
+  // @ts-ignore TYPE NEEDS FIXING
   variables: {} = undefined
 ): Promise<TridentPool[]> => {
+  // @ts-ignore TYPE NEEDS FIXING
   const result: TridentPoolQueryResult = await fetcher(chainId, getTridentPoolsQuery, variables)
   return formatPools(chainId, result)
 }
@@ -115,6 +119,7 @@ const formatBuckets = (buckets: PoolBucketQueryResult[]): PoolBucket[] =>
     transactionCount: Number(bucket.transactionCount),
   }))
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getPoolHourBuckets = async (chainId: ChainId = ChainId.ETHEREUM, variables): Promise<PoolBucket[]> => {
   const result: PoolBucketQueryResult[] = Object.values(
     await fetcher(chainId, poolHourSnapshotsQuery, variables)
@@ -122,6 +127,7 @@ export const getPoolHourBuckets = async (chainId: ChainId = ChainId.ETHEREUM, va
   return formatBuckets(result)
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getPoolDayBuckets = async (chainId: ChainId = ChainId.ETHEREUM, variables): Promise<PoolBucket[]> => {
   const result: PoolBucketQueryResult[] = Object.values(
     await fetcher(chainId, poolDaySnapshotsQuery, variables)
@@ -129,6 +135,7 @@ export const getPoolDayBuckets = async (chainId: ChainId = ChainId.ETHEREUM, var
   return formatBuckets(result)
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getTridentPoolTransactions = async (poolAddress) => {
   return await pager('https://api.thegraph.com/subgraphs/name/sushiswap/trident', getSwapsForPoolQuery, {
     poolAddress: poolAddress.toLowerCase(),
@@ -166,6 +173,7 @@ const formatKpis = (kpis: PoolKpiQueryResult[]): PoolKpi[] =>
     transactionCount: Number(transactionCount),
   }))
 
+// @ts-ignore TYPE NEEDS FIXING
 export const getPoolKpis = async (chainId: ChainId = ChainId.ETHEREUM, variables): Promise<PoolKpi[]> => {
   const result: PoolKpiQueryResult[] = Object.values(
     await fetcher(chainId, poolKpisQuery, variables)

--- a/src/services/graph/fetchers/status.ts
+++ b/src/services/graph/fetchers/status.ts
@@ -2,8 +2,10 @@ import { ChainId } from '@sushiswap/core-sdk'
 import { GRAPH_HOST } from 'app/services/graph/constants'
 import { request } from 'graphql-request'
 
+// @ts-ignore TYPE NEEDS FIXING
 export const status = async (chainId = ChainId.ETHEREUM, subgraphName) =>
   request(
+    // @ts-ignore TYPE NEEDS FIXING
     `${GRAPH_HOST[chainId]}/index-node/graphql`,
     `
         indexingStatusForCurrentVersion(subgraphName: "${subgraphName}") {

--- a/src/services/graph/fetchers/tokens.ts
+++ b/src/services/graph/fetchers/tokens.ts
@@ -23,8 +23,10 @@ interface TridentTokenPricesQueryResult {
 
 export const getTridentTokenPrices = async (
   chainId: ChainId = ChainId.ETHEREUM,
+  // @ts-ignore TYPE NEEDS FIXING
   variables: {} = undefined
 ): Promise<CurrencyAmount<Currency>[]> => {
+  // @ts-ignore TYPE NEEDS FIXING
   const { tokenPrices }: TridentTokenPricesQueryResult = await fetcher(chainId, getTridentTokenPricesQuery, variables)
   return formatCurrencyAmounts(chainId, tokenPrices)
 }
@@ -35,9 +37,12 @@ interface TridentTokenPriceQueryResult {
 
 export const getTridentTokenPrice = async (
   chainId: ChainId = ChainId.ETHEREUM,
+  // @ts-ignore TYPE NEEDS FIXING
   variables: {} = undefined
+  // @ts-ignore TYPE NEEDS FIXING
 ): Promise<CurrencyAmount<Currency>> => {
   try {
+    // @ts-ignore TYPE NEEDS FIXING
     const { tokenPrice }: TridentTokenPriceQueryResult = await fetcher(chainId, getTridentTokenPriceQuery, variables)
     return formatCurrencyAmounts(chainId, [tokenPrice])?.[0]
   } catch (e) {

--- a/src/services/graph/functions/index.ts
+++ b/src/services/graph/functions/index.ts
@@ -1,5 +1,6 @@
 import { request } from 'graphql-request'
 
+// @ts-ignore TYPE NEEDS FIXING
 export async function pager(endpoint, query, variables = {}) {
   if (endpoint.includes('undefined')) return {}
 

--- a/src/services/graph/hooks/bar.ts
+++ b/src/services/graph/hooks/bar.ts
@@ -9,6 +9,7 @@ interface useBarProps {
 }
 
 export function useBar({ variables, shouldFetch = true, swrConfig = undefined }: useBarProps = {}) {
+  // @ts-ignore TYPE NEEDS FIXING
   const { data } = useSWR(shouldFetch ? ['bar', stringify(variables)] : null, () => getBar(variables), swrConfig)
   return data
 }
@@ -22,6 +23,7 @@ interface useBarHistoryProps {
 export function useBarHistory({ variables, shouldFetch = true, swrConfig = undefined }: useBarHistoryProps = {}) {
   const { data } = useSWR(
     shouldFetch ? ['barHistory', stringify(variables)] : null,
+    // @ts-ignore TYPE NEEDS FIXING
     () => getBarHistory(variables),
     swrConfig
   )

--- a/src/services/graph/hooks/bentobox.ts
+++ b/src/services/graph/hooks/bentobox.ts
@@ -14,6 +14,7 @@ import useSWR from 'swr'
 
 import { GraphProps } from '../interfaces'
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useClones({ chainId, shouldFetch = true, swrConfig = undefined }) {
   const { data } = useSWR(shouldFetch ? () => ['clones', chainId] : null, (_, chainId) => getClones(chainId), swrConfig)
   return data
@@ -27,6 +28,7 @@ export function useKashiPairs({
 }: GraphProps) {
   const { data } = useSWR(
     shouldFetch ? () => ['kashiPairs', chainId, stringify(variables)] : null,
+    // @ts-ignore TYPE NEEDS FIXING
     (_, chainId) => getKashiPairs(chainId, variables),
     swrConfig
   )
@@ -62,6 +64,7 @@ export function useBentoStrategies({
 export function useBentoTokens({
   chainId,
   variables,
+  // @ts-ignore TYPE NEEDS FIXING
   shouldFetch = featureEnabled(Feature.BENTOBOX, chainId),
   swrConfig = undefined,
 }: GraphProps) {
@@ -76,6 +79,7 @@ export function useBentoTokens({
 export function useBentoUserTokens({
   chainId,
   variables,
+  // @ts-ignore TYPE NEEDS FIXING
   shouldFetch = featureEnabled(Feature.BENTOBOX, chainId),
   swrConfig = undefined,
 }: GraphProps) {

--- a/src/services/graph/hooks/exchange.ts
+++ b/src/services/graph/hooks/exchange.ts
@@ -44,6 +44,7 @@ export function useFactory({
 }: GraphProps) {
   const { data } = useSWR(
     shouldFetch ? ['factory', chainId, stringify(variables)] : null,
+    // @ts-ignore TYPE NEEDS FIXING
     () => getFactory(chainId, variables),
     swrConfig
   )
@@ -58,6 +59,7 @@ export function useNativePrice({
 }: GraphProps) {
   const { data } = useSWR(
     shouldFetch ? ['nativePrice', chainId, stringify(variables)] : null,
+    // @ts-ignore TYPE NEEDS FIXING
     () => getNativePrice(chainId, variables),
     swrConfig
   )
@@ -65,11 +67,13 @@ export function useNativePrice({
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useEthPrice(variables = undefined, swrConfig: SWRConfiguration = undefined) {
   const { data } = useSWR(['ethPrice'], () => getNativePrice(variables), swrConfig)
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useGnoPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.XDAI
@@ -77,16 +81,19 @@ export function useGnoPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useSpellPrice(swrConfig: SWRConfiguration = undefined) {
   const { data } = useSWR('spellPrice', () => getSpellPrice(), swrConfig)
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useOnePrice(swrConfig: SWRConfiguration = undefined) {
   const { data } = useSWR(['onePrice'], () => getOnePrice(), swrConfig)
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useCeloPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.CELO
@@ -94,6 +101,7 @@ export function useCeloPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useMovrPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.MOONRIVER
@@ -101,6 +109,7 @@ export function useMovrPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useYggPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.ETHEREUM
@@ -108,6 +117,7 @@ export function useYggPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useRulerPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.ETHEREUM
@@ -115,12 +125,14 @@ export function useRulerPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useTruPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const { data } = useSWR(chainId && chainId === ChainId.ETHEREUM ? ['truPrice'] : null, () => getTruPrice(), swrConfig)
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useAlcxPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.ETHEREUM
@@ -128,6 +140,7 @@ export function useAlcxPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useCvxPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.ETHEREUM
@@ -135,6 +148,7 @@ export function useCvxPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function usePicklePrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.ETHEREUM
@@ -142,6 +156,7 @@ export function usePicklePrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useMphPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.ETHEREUM
@@ -149,21 +164,25 @@ export function useMphPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useAvaxPrice(swrConfig: SWRConfiguration = undefined) {
   const { data } = useSWR(['avaxPrice'], () => getAvaxPrice(), swrConfig)
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useMaticPrice(swrConfig: SWRConfiguration = undefined) {
   const { data } = useSWR(['maticPrice'], () => getMaticPrice(), swrConfig)
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useSushiPrice(swrConfig: SWRConfiguration = undefined) {
   const { data } = useSWR(['sushiPrice'], () => getSushiPrice(), swrConfig)
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useOhmPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId
@@ -171,6 +190,7 @@ export function useOhmPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useFusePrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.FUSE
@@ -178,6 +198,7 @@ export function useFusePrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useMagicPrice(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.ARBITRUM
@@ -185,6 +206,7 @@ export function useMagicPrice(swrConfig: SWRConfiguration = undefined) {
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useBundle(variables = undefined, swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const { data } = useSWR(chainId ? [chainId, ethPriceQuery, stringify(variables)] : null, () => getBundle(), swrConfig)
@@ -213,6 +235,7 @@ export function useSushiPairs({
 }: GraphProps) {
   const { data } = useSWR(
     shouldFetch ? ['sushiPairs', chainId, stringify(variables)] : null,
+    // @ts-ignore TYPE NEEDS FIXING
     (_, chainId) => getPairs(chainId, variables),
     swrConfig
   )
@@ -249,6 +272,7 @@ export function usePairDayData({
 
 export function useTokenDayData(
   { chainId, variables, shouldFetch = true }: GraphProps,
+  // @ts-ignore TYPE NEEDS FIXING
   swrConfig: SWRConfiguration = undefined
 ) {
   const { data } = useSWR(
@@ -262,6 +286,7 @@ export function useTokenDayData(
 export function useDayData({ chainId, variables, shouldFetch = true, swrConfig = undefined }: GraphProps) {
   const { data } = useSWR(
     shouldFetch && !!chainId ? ['dayData', chainId, stringify(variables)] : null,
+    // @ts-ignore TYPE NEEDS FIXING
     (_, chainId) => getDayData(chainId, variables),
     swrConfig
   )
@@ -276,6 +301,7 @@ export function useTokenPairs({
 }: GraphProps) {
   const { data } = useSWR(
     shouldFetch ? ['tokenPairs', chainId, stringify(variables)] : null,
+    // @ts-ignore TYPE NEEDS FIXING
     (_, chainId) => getTokenPairs(chainId, variables),
     swrConfig
   )

--- a/src/services/graph/hooks/masterchef.ts
+++ b/src/services/graph/hooks/masterchef.ts
@@ -48,6 +48,7 @@ export function useMasterChefV1Farms({ chainId, swrConfig = undefined }: useFarm
   const { data } = useSWR(shouldFetch ? ['masterChefV1Farms'] : null, () => getMasterChefV1Farms(undefined), swrConfig)
   return useMemo(() => {
     if (!data) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return data.map((data) => ({ ...data, chef: Chef.MASTERCHEF }))
   }, [data])
 }
@@ -57,10 +58,12 @@ export function useMasterChefV2Farms({ chainId, swrConfig = undefined }: useFarm
   const { data } = useSWR(shouldFetch ? 'masterChefV2Farms' : null, () => getMasterChefV2Farms(), swrConfig)
   return useMemo(() => {
     if (!data) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return data.map((data) => ({ ...data, chef: Chef.MASTERCHEF_V2 }))
   }, [data])
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useOldMiniChefFarms(swrConfig: SWRConfiguration = undefined) {
   const { chainId } = useActiveWeb3React()
   const shouldFetch = chainId && chainId === ChainId.CELO
@@ -72,6 +75,7 @@ export function useOldMiniChefFarms(swrConfig: SWRConfiguration = undefined) {
 
   return useMemo(() => {
     if (!data) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return data.map((data) => ({ ...data, chef: Chef.OLD_FARMS }))
   }, [data])
 }
@@ -95,6 +99,7 @@ export function useMiniChefFarms({ chainId, swrConfig = undefined }: useFarmsPro
   )
   return useMemo(() => {
     if (!data) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return data.map((data) => ({ ...data, chef: Chef.MINICHEF }))
   }, [data])
 }
@@ -119,6 +124,7 @@ export function useMasterChefV1PairAddresses() {
   )
   return useMemo(() => {
     if (!data) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return data.map((data) => data.pair)
   }, [data])
 }
@@ -131,6 +137,7 @@ export function useMasterChefV2PairAddresses() {
   )
   return useMemo(() => {
     if (!data) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return data.map((data) => data.pair)
   }, [data])
 }
@@ -153,6 +160,7 @@ export function useMiniChefPairAddresses() {
   )
   return useMemo(() => {
     if (!data) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return data.map((data) => data.pair)
   }, [data])
 }

--- a/src/services/graph/hooks/pools.ts
+++ b/src/services/graph/hooks/pools.ts
@@ -56,6 +56,7 @@ export function usePoolDayBuckets({
   return data
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function usePoolKpis({ chainId, variables, shouldFetch = true, swrConfig = undefined }) {
   return useSWR(
     shouldFetch && !!chainId ? ['trident-pool-kpis', chainId, variables] : null,
@@ -64,6 +65,7 @@ export function usePoolKpis({ chainId, variables, shouldFetch = true, swrConfig 
   )
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useOneDayPoolKpis({ chainId, variables, shouldFetch = true, swrConfig = undefined }) {
   const oneDayBlock = useOneDayBlock({ chainId, shouldFetch: !!chainId })
   const _variables = {
@@ -78,6 +80,7 @@ export function useOneDayPoolKpis({ chainId, variables, shouldFetch = true, swrC
   )
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useTwoDayPoolKpis({ chainId, variables, shouldFetch = true, swrConfig = undefined }) {
   const twoDayBlock = useTwoDayBlock({ chainId, shouldFetch: !!chainId })
   const _variables = {
@@ -92,6 +95,7 @@ export function useTwoDayPoolKpis({ chainId, variables, shouldFetch = true, swrC
   )
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useRollingPoolStats({ chainId, variables, shouldFetch = true, swrConfig = undefined }) {
   const {
     data: poolKpis,

--- a/src/services/graph/hooks/positions.ts
+++ b/src/services/graph/hooks/positions.ts
@@ -2,6 +2,7 @@ import { getTridentPositions } from 'app/services/graph'
 import stringify from 'fast-json-stable-stringify'
 import useSWR from 'swr'
 
+// @ts-ignore TYPE NEEDS FIXING
 export const useTridentLiquidityPositions = ({ chainId, variables, shouldFetch = true, swrConfig = undefined }) => {
   return useSWR(
     shouldFetch && !!chainId ? ['trident-liquidity-positions', chainId, stringify(variables)] : null,

--- a/src/services/graph/hooks/tokens.ts
+++ b/src/services/graph/hooks/tokens.ts
@@ -1,6 +1,7 @@
 import { getTridentTokenPrice, getTridentTokenPrices } from 'app/services/graph'
 import useSWR from 'swr'
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useTridentTokenPrices({ chainId, variables, shouldFetch = true, swrConfig = undefined }) {
   return useSWR(
     shouldFetch && !!chainId ? ['trident-token-prices', chainId, variables] : null,
@@ -9,6 +10,7 @@ export function useTridentTokenPrices({ chainId, variables, shouldFetch = true, 
   )
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useTridentTokenPrice({ chainId, variables, shouldFetch = true, swrConfig = undefined }) {
   return useSWR(
     shouldFetch && !!chainId ? ['trident-token-price', chainId, variables] : null,

--- a/src/services/graph/hooks/transactions/legacy.ts
+++ b/src/services/graph/hooks/transactions/legacy.ts
@@ -52,6 +52,7 @@ export const useLegacyTransactions = (pairs?: string[]) => {
   const variables = { where: { pair_in: pairs } }
   const { data, error, isValidating } = useSWR<LegacyTransactions[]>(
     !!chainId && !!pairs ? ['legacyTransactions', chainId, JSON.stringify(variables)] : null,
+    // @ts-ignore TYPE NEEDS FIXING
     () => getTransactions(chainId, variables)
   )
   const transactions = useMemo(() => legacyTransactionDataFormatter(data || []), [data])

--- a/src/services/local-forage/fetcher.ts
+++ b/src/services/local-forage/fetcher.ts
@@ -1,6 +1,7 @@
 import localForage from 'localforage'
 
 // Defaults to IndexDB, can change strategy.
+// @ts-ignore TYPE NEEDS FIXING
 export default async function fetcher(key) {
   try {
     const value = await localForage.getItem<string>(key)

--- a/src/services/local-storage/fetcher.ts
+++ b/src/services/local-storage/fetcher.ts
@@ -1,4 +1,5 @@
 // Simple local storage fetcher
+// @ts-ignore TYPE NEEDS FIXING
 export default async function fetcher(key) {
   const value = localStorage.getItem(key)
   if (!value) return undefined

--- a/src/services/redis/index.ts
+++ b/src/services/redis/index.ts
@@ -1,3 +1,4 @@
+// @ts-ignore TYPE NEEDS FIXING
 import Redis from 'ioredis'
 
 const redis = new Redis(process.env.REDIS_URL)

--- a/src/services/web3/hooks/useQueryFilter.ts
+++ b/src/services/web3/hooks/useQueryFilter.ts
@@ -3,6 +3,7 @@ import { ChainId } from '@sushiswap/core-sdk'
 import stringify from 'fast-json-stable-stringify'
 import useSWR from 'swr'
 
+// @ts-ignore TYPE NEEDS FIXING
 async function queryFilter(contract: Contract, event, fromBlockOrBlockHash, toBlock) {
   return await contract.queryFilter(event, fromBlockOrBlockHash, toBlock)
 }
@@ -10,7 +11,9 @@ async function queryFilter(contract: Contract, event, fromBlockOrBlockHash, toBl
 export function useQueryFilter({
   chainId = ChainId.ETHEREUM,
   shouldFetch = true,
+  // @ts-ignore TYPE NEEDS FIXING
   contract,
+  // @ts-ignore TYPE NEEDS FIXING
   event,
   fromBlockOrBlockHash = undefined,
   toBlock = undefined,

--- a/src/services/zerion/fetchers.ts
+++ b/src/services/zerion/fetchers.ts
@@ -58,6 +58,7 @@ export const getAssets = async (account: string) => {
 
   return Object.keys(assets)
     .map((key) => {
+      // @ts-ignore TYPE NEEDS FIXING
       const network = Networks[key.split(' ')[2]]
       return Object.values(assets[key][Object.keys(assets[key])[0]]).map((asset: any) => {
         return {

--- a/src/services/zerion/hooks.ts
+++ b/src/services/zerion/hooks.ts
@@ -3,8 +3,10 @@ import useSWR, { SWRConfiguration } from 'swr'
 
 import { getAssets } from './fetchers'
 
+// @ts-ignore TYPE NEEDS FIXING
 export function useAssets(swrConfig: SWRConfiguration = undefined) {
   const { account } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const { data } = useSWR(account ? ['userAssets', account] : null, () => getAssets(account), swrConfig)
   return data
 }

--- a/src/state/application/hooks.ts
+++ b/src/state/application/hooks.ts
@@ -95,6 +95,7 @@ export function useRemovePopup(): (key: string) => void {
 // get the list of active popups
 export function useActivePopups(): AppState['application']['popupList'] {
   const list = useSelector((state: AppState) => state.application.popupList)
+  // @ts-ignore TYPE NEEDS FIXING
   return useMemo(() => list.filter((item) => item.show), [list])
 }
 

--- a/src/state/application/reducer.test.ts
+++ b/src/state/application/reducer.test.ts
@@ -8,6 +8,7 @@ describe('application reducer', () => {
   let store: Store<ApplicationState>
 
   beforeEach(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     store = createStore(reducer, {
       popupList: [],
       blockNumber: {

--- a/src/state/application/updater.ts
+++ b/src/state/application/updater.ts
@@ -17,7 +17,9 @@ export default function Updater(): null {
 
   useEffect(() => {
     if (chainId === ChainId.CELO) {
+      // @ts-ignore TYPE NEEDS FIXING
       const originalBlockFormatter = library.formatter._block
+      // @ts-ignore TYPE NEEDS FIXING
       library.formatter._block = (value, format) => {
         return originalBlockFormatter(
           {
@@ -30,6 +32,7 @@ export default function Updater(): null {
     }
     return () => {
       if (chainId === ChainId.CELO) {
+        // @ts-ignore TYPE NEEDS FIXING
         library.formatter._block = (value: any, format: any): Block => {
           if (value.author != null && value.miner == null) {
             value.miner = value.author
@@ -64,7 +67,9 @@ export default function Updater(): null {
             return { chainId, blockNumber: block.number, blockTimestamp: block.timestamp }
           return {
             chainId,
+            // @ts-ignore TYPE NEEDS FIXING
             blockNumber: Math.max(block.number, state.blockNumber),
+            // @ts-ignore TYPE NEEDS FIXING
             blockTimestamp: Math.max(block.timestamp, state.blockTimestamp),
           }
         }
@@ -76,6 +81,7 @@ export default function Updater(): null {
 
   const onBlock = useCallback(
     (number) => {
+      // @ts-ignore TYPE NEEDS FIXING
       return library.getBlock(number).then(blockCallback)
     },
     [blockCallback, library]
@@ -111,6 +117,7 @@ export default function Updater(): null {
   }, [windowVisible, dispatch, debouncedState.blockTimestamp, debouncedState.chainId])
 
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     dispatch(updateChainId({ chainId: debouncedState.chainId in ChainId ? debouncedState.chainId ?? null : null }))
   }, [dispatch, debouncedState.chainId])
 

--- a/src/state/burn/hooks.ts
+++ b/src/state/burn/hooks.ts
@@ -97,8 +97,11 @@ export function useDerivedBurnInfo(
   }
   // user specified a specific amount of token a or b
   else {
+    // @ts-ignore TYPE NEEDS FIXING
     if (tokens[independentField]) {
+      // @ts-ignore TYPE NEEDS FIXING
       const independentAmount = tryParseAmount(typedValue, tokens[independentField])
+      // @ts-ignore TYPE NEEDS FIXING
       const liquidityValue = liquidityValues[independentField]
       if (independentAmount && liquidityValue && !independentAmount.greaterThan(liquidityValue)) {
         percentToRemove = new Percent(independentAmount.quotient, liquidityValue.quotient)

--- a/src/state/inari/hooks.tsx
+++ b/src/state/inari/hooks.tsx
@@ -40,6 +40,7 @@ export function useDerivedInariState(): DerivedInariState {
     [tokens.outputToken.address, tokens.outputToken.chainId, tokens.outputToken.decimals, tokens.outputToken.symbol]
   )
 
+  // @ts-ignore TYPE NEEDS FIXING
   return useMemo(
     () => ({
       ...rest,

--- a/src/state/inari/reducer.ts
+++ b/src/state/inari/reducer.ts
@@ -9,6 +9,7 @@ const initialState: InariState = {
   zapIn: true,
   inputValue: '',
   outputValue: '',
+  // @ts-ignore TYPE NEEDS FIXING
   general: null,
   tokens: tokenDefinitions,
 }

--- a/src/state/inari/strategies/useBaseStrategy.ts
+++ b/src/state/inari/strategies/useBaseStrategy.ts
@@ -110,6 +110,7 @@ const useBaseStrategy = ({ id, general, tokenDefinitions }: useBaseStrategyInter
       inputTokenBalance?: CurrencyAmount<Token>
       outputTokenBalance?: CurrencyAmount<Token>
     }) => {
+      // @ts-ignore TYPE NEEDS FIXING
       _setBalances((prevState) => ({
         ...prevState,
         inputTokenBalance,
@@ -119,6 +120,7 @@ const useBaseStrategy = ({ id, general, tokenDefinitions }: useBaseStrategyInter
     []
   )
 
+  // @ts-ignore TYPE NEEDS FIXING
   return useMemo(
     () => ({
       id,

--- a/src/state/inari/strategies/useStakeSushiToAaveStrategy.ts
+++ b/src/state/inari/strategies/useStakeSushiToAaveStrategy.ts
@@ -40,6 +40,7 @@ export const tokenDefinitions: StrategyTokenDefinitions = {
 const useStakeSushiToAaveStrategy = (): StrategyHook => {
   const { i18n } = useLingui()
   const { account } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const balances = useTokenBalances(account, [SUSHI[ChainId.ETHEREUM], AXSUSHI])
   const general = useMemo(() => GENERAL(i18n), [i18n])
   const { setBalances, ...strategy } = useBaseStrategy({
@@ -52,6 +53,7 @@ const useStakeSushiToAaveStrategy = (): StrategyHook => {
     if (!balances) return
 
     setBalances({
+      // @ts-ignore TYPE NEEDS FIXING
       inputTokenBalance: balances[SUSHI[ChainId.ETHEREUM].address],
       outputTokenBalance: balances[AXSUSHI.address],
     })

--- a/src/state/inari/strategies/useStakeSushiToBentoStrategy.ts
+++ b/src/state/inari/strategies/useStakeSushiToBentoStrategy.ts
@@ -42,6 +42,7 @@ export const tokenDefinitions: StrategyTokenDefinitions = {
 const useStakeSushiToBentoStrategy = (): StrategyHook => {
   const { i18n } = useLingui()
   const { account } = useActiveWeb3React()
+  // @ts-ignore TYPE NEEDS FIXING
   const balances = useTokenBalances(account, [SUSHI[ChainId.ETHEREUM], XSUSHI])
   const xSushiBentoBalance = useBentoBalanceV2(XSUSHI.address)
 

--- a/src/state/inari/strategies/useStakeSushiToCreamStrategy.ts
+++ b/src/state/inari/strategies/useStakeSushiToCreamStrategy.ts
@@ -47,11 +47,13 @@ const useStakeSushiToCreamStrategy = (): StrategyHook => {
   const { zapIn, inputValue } = useDerivedInariState()
   const zenkoContract = useZenkoContract()
   const inariContract = useInariContract()
+  // @ts-ignore TYPE NEEDS FIXING
   const balances = useTokenBalances(account, [SUSHI[ChainId.ETHEREUM], CRXSUSHI])
   const cTokenAmountRef = useRef<CurrencyAmount<Token>>(null)
   const approveAmount = useMemo(() => (zapIn ? inputValue : cTokenAmountRef.current), [inputValue, zapIn])
 
   // Override approveCallback for this strategy as we need to approve CRXSUSHI on zapOut
+  // @ts-ignore TYPE NEEDS FIXING
   const approveCallback = useApproveCallback(approveAmount, inariContract?.address)
   const general = useMemo(() => GENERAL(i18n), [i18n])
   const { execute, setBalances, ...baseStrategy } = useBaseStrategy({
@@ -75,12 +77,14 @@ const useStakeSushiToCreamStrategy = (): StrategyHook => {
   const preExecute = useCallback(
     async (val: CurrencyAmount<Token>) => {
       if (zapIn) return execute(val)
+      // @ts-ignore TYPE NEEDS FIXING
       return execute(await toCTokenAmount(val))
     },
     [execute, toCTokenAmount, zapIn]
   )
 
   useEffect(() => {
+    // @ts-ignore TYPE NEEDS FIXING
     toCTokenAmount(inputValue).then((val) => (cTokenAmountRef.current = val))
   }, [inputValue, toCTokenAmount])
 
@@ -94,6 +98,7 @@ const useStakeSushiToCreamStrategy = (): StrategyHook => {
         balances[CRXSUSHI.address].toFixed().toBigNumber(CRXSUSHI.decimals).toString()
       )
       setBalances({
+        // @ts-ignore TYPE NEEDS FIXING
         inputTokenBalance: balances[SUSHI[ChainId.ETHEREUM].address],
         outputTokenBalance: CurrencyAmount.fromRawAmount(XSUSHI, bal.toString()),
       })
@@ -102,6 +107,7 @@ const useStakeSushiToCreamStrategy = (): StrategyHook => {
     main()
   }, [balances, setBalances, zenkoContract])
 
+  // @ts-ignore TYPE NEEDS FIXING
   return useMemo(
     () => ({
       ...baseStrategy,

--- a/src/state/inari/strategies/useStakeSushiToCreamToBentoStrategy.ts
+++ b/src/state/inari/strategies/useStakeSushiToCreamToBentoStrategy.ts
@@ -45,6 +45,7 @@ const useStakeSushiToCreamToBentoStrategy = (): StrategyHook => {
   const { i18n } = useLingui()
   const { account } = useActiveWeb3React()
   const zenkoContract = useZenkoContract()
+  // @ts-ignore TYPE NEEDS FIXING
   const balances = useTokenBalances(account, [SUSHI[ChainId.ETHEREUM]])
   const sushiPerXSushi = useSushiPerXSushi(true)
   const crxSushiBentoBalance = useBentoBalanceV2(CRXSUSHI.address)

--- a/src/state/inari/traits/useBentoBoxTrait.ts
+++ b/src/state/inari/traits/useBentoBoxTrait.ts
@@ -26,11 +26,13 @@ export interface BaseStrategyWithBentoBoxTraitHook
 // Strategies that end up in BentoBox don't need to to approve inari to spend tokens when unzapping
 // hence the approveCallback is null when unzapping
 const useBentoBoxTrait = (props: BaseStrategyHook): BaseStrategyWithBentoBoxTraitHook => {
+  // @ts-ignore TYPE NEEDS FIXING
   const trait = useTrait(props, TRAIT_CONFIG)
   const { account } = useActiveWeb3React()
   const { zapIn } = useDerivedInariState()
   const inariContract = useInariContract()
   const addTransaction = useTransactionAdder()
+  // @ts-ignore TYPE NEEDS FIXING
   const bentoApproveCallback = useBentoMasterApproveCallback(inariContract.address, {
     otherBentoBoxContract: inariContract,
     contractName: 'Inari',

--- a/src/state/inari/traits/useHasPermitTokenTrait.ts
+++ b/src/state/inari/traits/useHasPermitTokenTrait.ts
@@ -18,6 +18,7 @@ export interface BaseStrategyWithHasPermitTokenHook extends BaseStrategyHook, Ba
 // Use this BaseStrategy when outputToken allows for a batched permitToken
 // THIS TRAIT IS UNTESTED, PLEASE TEST THOROUGHLY BEFORE USING
 const useHasPermitTokenTrait = (props: BaseStrategyHook): BaseStrategyWithHasPermitTokenHook => {
+  // @ts-ignore TYPE NEEDS FIXING
   const trait = useTrait(props, TRAIT_CONFIG)
   const { account } = useActiveWeb3React()
   const { zapIn, inputValue } = useDerivedInariState()
@@ -44,6 +45,7 @@ const useHasPermitTokenTrait = (props: BaseStrategyHook): BaseStrategyWithHasPer
             ]),
           ]
 
+          // @ts-ignore TYPE NEEDS FIXING
           const tx = await inariContract.batch(batch, true)
           addTransaction(tx, {
             summary: `Approve Inari Master Contract and ${zapIn ? 'Deposit' : 'Withdraw'} ${

--- a/src/state/inari/traits/useTrait.ts
+++ b/src/state/inari/traits/useTrait.ts
@@ -5,6 +5,7 @@ export interface BaseTrait {
   overrides: string[]
 }
 
+// @ts-ignore TYPE NEEDS FIXING
 const useTrait = (props, { overrides = [] }) => {
   useEffect(() => {
     const intersection = overrides.filter((value) => (props.overrides || []).includes(value))

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -4,6 +4,7 @@ import storage from 'redux-persist/lib/storage'
 
 import reducer from './reducer'
 
+// @ts-ignore TYPE NEEDS FIXING
 let store
 
 const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists']
@@ -32,13 +33,17 @@ function makeStore(preloadedState = undefined) {
 }
 
 export const getOrCreateStore = (preloadedState = undefined) => {
+  // @ts-ignore TYPE NEEDS FIXING
   let _store = store ?? makeStore(preloadedState)
 
   // After navigating to a page with an initial Redux state, merge that state
   // with the current state in the store, and create a new store
+  // @ts-ignore TYPE NEEDS FIXING
   if (preloadedState && store) {
     _store = makeStore({
+      //@ts-ignore TYPE NEEDS FIXING
       ...store.getState(),
+      //@ts-ignore TYPE NEEDS FIXING
       ...preloadedState,
     })
     // Reset the current store
@@ -49,6 +54,7 @@ export const getOrCreateStore = (preloadedState = undefined) => {
   if (typeof window === 'undefined') return _store
 
   // Create the store once in the client
+  // @ts-ignore TYPE NEEDS FIXING
   if (!store) store = _store
 
   return _store

--- a/src/state/limit-order/hooks.ts
+++ b/src/state/limit-order/hooks.ts
@@ -175,6 +175,7 @@ export const useLimitOrderDerivedCurrencies: UseLimitOrderDerivedCurrencies = ()
   } = useLimitOrderState()
 
   const inputCurrency = useCurrency(inputCurrencyId || 'ETH') ?? undefined
+  // @ts-ignore TYPE NEEDS FIXING
   const outputCurrency = useCurrency(outputCurrencyId || SUSHI_ADDRESS[chainId]) ?? undefined
 
   return useMemo(() => {
@@ -285,7 +286,9 @@ export const useLimitOrderDerivedTrade = () => {
     exactIn
       ? parsedInputAmount ||
           CurrencyAmount.fromRawAmount(
+            // @ts-ignore TYPE NEEDS FIXING
             inputCurrency,
+            // @ts-ignore TYPE NEEDS FIXING
             JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(inputCurrency.decimals))
           )
       : undefined,
@@ -300,7 +303,9 @@ export const useLimitOrderDerivedTrade = () => {
     !exactIn
       ? parsedOutputAmount ||
           CurrencyAmount.fromRawAmount(
+            // @ts-ignore TYPE NEEDS FIXING
             outputCurrency,
+            // @ts-ignore TYPE NEEDS FIXING
             JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(outputCurrency.decimals))
           )
       : undefined,

--- a/src/state/limit-order/reducer.ts
+++ b/src/state/limit-order/reducer.ts
@@ -65,6 +65,7 @@ const initialState: LimitOrderState = {
 export default createReducer<LimitOrderState>(initialState, (builder) =>
   builder
     .addCase(
+      // @ts-ignore TYPE NEEDS FIXING
       replaceLimitOrderState,
       (
         state,
@@ -97,12 +98,14 @@ export default createReducer<LimitOrderState>(initialState, (builder) =>
       })
     )
     .addCase(setLimitPrice, (state, { payload: limitPrice }) => {
+      // @ts-ignore TYPE NEEDS FIXING
       state.limitPrice = limitPrice
     })
     .addCase(setLimitOrderApprovalPending, (state, { payload: limitOrderApprovalPending }) => {
       state.limitOrderApprovalPending = limitOrderApprovalPending
     })
     .addCase(setOrderExpiration, (state, { payload: orderExpiration }) => {
+      // @ts-ignore TYPE NEEDS FIXING
       state.orderExpiration = orderExpiration
     })
     .addCase(setFromBentoBalance, (state, { payload: fromBentoBalance }) => {

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -109,6 +109,7 @@ function useCombinedTokenMapFromUrls(urls: string[] | undefined): TokenAddressMa
 
 // filter out unsupported lists
 export function useActiveListUrls(): string[] | undefined {
+  // @ts-ignore TYPE NEEDS FIXING
   return useAppSelector((state) => state.lists.activeListUrls)?.filter((url) => !UNSUPPORTED_LIST_URLS.includes(url))
 }
 

--- a/src/state/lists/reducer.ts
+++ b/src/state/lists/reducer.ts
@@ -50,7 +50,9 @@ export default createReducer(initialState, (builder) =>
   builder
     .addCase(fetchTokenList.pending, (state, { payload: { requestId, url } }) => {
       state.byUrl[url] = {
+        // @ts-ignore TYPE NEEDS FIXING
         current: null,
+        // @ts-ignore TYPE NEEDS FIXING
         pendingUpdate: null,
         ...state.byUrl[url],
         loadingRequestId: requestId,

--- a/src/state/mint/hooks.ts
+++ b/src/state/mint/hooks.ts
@@ -114,6 +114,7 @@ export function useDerivedMintInfo(
   // amounts
   const independentAmount: CurrencyAmount<Currency> | undefined = tryParseAmount(
     typedValue,
+    // @ts-ignore TYPE NEEDS FIXING
     currencies[independentField]
   )
   const dependentAmount: CurrencyAmount<Currency> | undefined = useMemo(() => {

--- a/src/state/multicall/updater.tsx
+++ b/src/state/multicall/updater.tsx
@@ -35,6 +35,7 @@ async function fetchChunk(
     )
 
     if (process.env.NODE_ENV === 'development') {
+      // @ts-ignore TYPE NEEDS FIXING
       returnData.forEach(({ gasUsed, returnData, success }, i) => {
         if (
           !success &&
@@ -52,6 +53,7 @@ async function fetchChunk(
     }
     return returnData
   } catch (error) {
+    // @ts-ignore TYPE NEEDS FIXING
     if (error.code === -32000 || error.message?.indexOf('header not found') !== -1) {
       throw new RetryableError(`header not found for block number ${blockNumber}`)
     }

--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -188,6 +188,7 @@ export function useDerivedSwapInfo(): {
     inputError = inputError ?? i18n._(t`Enter a recipient`)
   } else {
     if (
+      // @ts-ignore TYPE NEEDS FIXING
       BAD_RECIPIENT_ADDRESSES?.[chainId]?.[formattedTo] ||
       (bestTradeExactIn && involvesAddress(bestTradeExactIn, formattedTo)) ||
       (bestTradeExactOut && involvesAddress(bestTradeExactOut, formattedTo))
@@ -196,6 +197,7 @@ export function useDerivedSwapInfo(): {
     }
   }
 
+  // @ts-ignore TYPE NEEDS FIXING
   const allowedSlippage = useSwapSlippageTolerance(v2Trade)
 
   // compare input balance to max input based on version

--- a/src/state/transactions/updater.tsx
+++ b/src/state/transactions/updater.tsx
@@ -120,6 +120,7 @@ export default function Updater(): null {
               }
 
               if (receipt.status === 0) {
+                // @ts-ignore TYPE NEEDS FIXING
                 sendRevertTransactionLog(hash, routeInfo)
               }
             } else {

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -172,6 +172,7 @@ export function useUserAddedTokens(): Token[] {
 
   return useMemo(() => {
     if (!chainId) return []
+    // @ts-ignore TYPE NEEDS FIXING
     return Object.values(serializedTokensMap?.[chainId] ?? {}).map(deserializeToken)
   }, [serializedTokensMap, chainId])
 }
@@ -225,6 +226,7 @@ export function toV2LiquidityToken([tokenA, tokenB]: [Token, Token]): Token {
 const computeOracleData = (collateral: Currency, asset: Currency) => {
   const oracleData = ''
 
+  // @ts-ignore TYPE NEEDS FIXING
   const mapping = CHAINLINK_PRICE_FEED_MAP[asset.chainId]
 
   for (const address in mapping) {
@@ -324,6 +326,7 @@ export function toKashiLiquidityToken([collateral, asset]: [Token, Token]): Toke
   //   oracleData: computeOracleData(collateral, asset),
   // })
   const oracleData = computeOracleData(collateral, asset)
+  // @ts-ignore TYPE NEEDS FIXING
   if (!oracleData) return
   return new Token(
     collateral.chainId,

--- a/src/state/wallet/hooks.ts
+++ b/src/state/wallet/hooks.ts
@@ -41,6 +41,7 @@ export function useETHBalances(uncheckedAddresses?: (string | undefined)[]): {
       addresses.reduce<{ [address: string]: CurrencyAmount<Currency> }>((memo, address, i) => {
         const value = results?.[i]?.result?.[0]
         if (value && chainId)
+          // @ts-ignore TYPE NEEDS FIXING
           memo[address] = CurrencyAmount.fromRawAmount(NATIVE[chainId], JSBI.BigInt(value.toString()))
         return memo
       }, {}),

--- a/test/e2e/helpers/ApprovalHelper.ts
+++ b/test/e2e/helpers/ApprovalHelper.ts
@@ -10,6 +10,7 @@ export class ApprovalHelper {
   constructor() {
     this.Provider = new JsonRpcProvider(process.env.INFURA_URL)
 
+    // @ts-ignore TYPE NEEDS FIXING
     const signer = new Wallet(process.env.TEST_PKEY, this.Provider)
     this.Signer = signer
   }

--- a/test/e2e/pages/AppPage.ts
+++ b/test/e2e/pages/AppPage.ts
@@ -47,9 +47,11 @@ export abstract class AppPage {
     if (web3Connected) return
 
     const btnConnectWallet = await this.Page.waitForSelector(this.WalletConnectSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await btnConnectWallet.click()
 
     const metamaskButton = await this.Page.waitForSelector(this.WalletOptionMetamaskSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await metamaskButton.click()
     await this.Metamask.approve()
     await this.bringToFront()
@@ -62,15 +64,18 @@ export abstract class AppPage {
     await this.closeMetamaskWhatsNew()
 
     const addTokenButton = await this.Metamask.page.waitForSelector('.add-token-button > button')
+    // @ts-ignore TYPE NEEDS FIXING
     await addTokenButton.click()
 
     const addressInput = await this.Metamask.page.waitForSelector('#custom-address')
+    // @ts-ignore TYPE NEEDS FIXING
     addressInput.type(tokenAddress)
 
     await this.Metamask.page.waitForTimeout(4000)
 
     this.Metamask.page.waitForSelector(`button[data-testid='page-container-footer-next']:not([disabled])`)
     const nextButton = await this.Metamask.page.waitForSelector(`button[data-testid='page-container-footer-next']`)
+    // @ts-ignore TYPE NEEDS FIXING
     await nextButton.click()
 
     const buttons = await this.Metamask.page.$$('footer > button')
@@ -86,6 +91,7 @@ export abstract class AppPage {
     await this.closeMetamaskWhatsNew()
 
     const assetMenutButton = await this.Metamask.page.waitForSelector(`li[data-testid="home__asset-tab"]`)
+    // @ts-ignore TYPE NEEDS FIXING
     await assetMenutButton.click()
     await this.blockingWait(1, true)
 
@@ -142,6 +148,7 @@ export abstract class AppPage {
     await this.blockingWait(1, true)
   }
 
+  // @ts-ignore TYPE NEEDS FIXING
   public async blockingWait(seconds, checkCi: boolean = false): Promise<void> {
     let waitSeconds = seconds
 
@@ -157,6 +164,7 @@ export abstract class AppPage {
     await this.Page.waitForSelector(switchId)
     const switchElement = await this.Page.$(switchId)
 
+    // @ts-ignore TYPE NEEDS FIXING
     const buttonElement = (await switchElement.$x('..'))[0]
     if (!buttonElement) {
       throw new Error(`Switch with id ${switchId} not found on the page. Check selector is valid.`)

--- a/test/e2e/pages/AppPageComponent.ts
+++ b/test/e2e/pages/AppPageComponent.ts
@@ -9,6 +9,7 @@ export abstract class AppPageComponent {
     this.Page = page
   }
 
+  // @ts-ignore TYPE NEEDS FIXING
   public async blockingWait(seconds, checkCi: boolean = false): Promise<void> {
     let waitSeconds = seconds
 

--- a/test/e2e/pages/pools/AddLiquidityPage.ts
+++ b/test/e2e/pages/pools/AddLiquidityPage.ts
@@ -47,14 +47,17 @@ export class AddLiquidityPage extends AppPage {
     }
 
     const confirmDepositButton = await this.Page.waitForSelector(this.ConfirmDepositButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await confirmDepositButton.click()
 
     const modalConfirmDepositButton = await this.Page.waitForSelector(this.ModalConfirmDepositButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await modalConfirmDepositButton.click()
 
     await this.confirmMetamaskTransaction()
 
     const backToPoolsButton = await this.Page.waitForSelector(this.BackToPoolsButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await backToPoolsButton.click()
 
     await this.blockingWait(5)
@@ -163,6 +166,7 @@ export class AddLiquidityPage extends AppPage {
     await this.Page.waitForSelector(this.FixedRatioCheckboxSelector)
     const fixedRateCheckbox = await this.Page.$(this.FixedRatioCheckboxSelector)
 
+    // @ts-ignore TYPE NEEDS FIXING
     return fixedRateCheckbox
   }
 

--- a/test/e2e/pages/pools/CreatePoolPage.ts
+++ b/test/e2e/pages/pools/CreatePoolPage.ts
@@ -92,16 +92,19 @@ export class CreatePoolPage extends AppPage {
 
   public async setPoolFee(fee: number): Promise<void> {
     const feeTierButton = await this.Page.waitForSelector(this.FeeTierSelector + fee)
+    // @ts-ignore TYPE NEEDS FIXING
     await feeTierButton.click()
   }
 
   public async setPoolType(poolType: string): Promise<void> {
     const poolTypeButton = await this.Page.waitForSelector(this.PoolTypeButtonSelector + poolType)
+    // @ts-ignore TYPE NEEDS FIXING
     await poolTypeButton.click()
   }
 
   public async clickContinueButton(): Promise<void> {
     const continueButton = await this.Page.waitForSelector(this.ClassicContinueButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await continueButton.click()
   }
 
@@ -123,9 +126,11 @@ export class CreatePoolPage extends AppPage {
       return
     }
 
+    // @ts-ignore TYPE NEEDS FIXING
     await btnReviewConfirm.click()
 
     const btnConfirmCreation = await this.Page.waitForSelector(this.ConfirmCreationButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await btnConfirmCreation.click()
 
     await this.confirmMetamaskTransaction()

--- a/test/e2e/pages/pools/LiquidityPoolsPage.ts
+++ b/test/e2e/pages/pools/LiquidityPoolsPage.ts
@@ -7,6 +7,7 @@ export class LiquidityPoolsPage extends AppPage {
 
   public async clickCreateNewPoolButton(): Promise<void> {
     const createNewPoolButton = await this.Page.waitForSelector(this.CreateNewPoolButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await createNewPoolButton.click()
   }
 

--- a/test/e2e/pages/pools/RemoveLiquidityPage.ts
+++ b/test/e2e/pages/pools/RemoveLiquidityPage.ts
@@ -46,9 +46,8 @@ export class RemoveLiquidityPage extends AppPage {
     await this.Page.waitForSelector(selector)
 
     const assetAEstimatedOutputDiv = await this.Page.$(selector)
-    const estimatedOutputString = (await (
-      await assetAEstimatedOutputDiv.getProperty('textContent')
-    ).jsonValue()) as string
+    const estimatedOutputString = (await // @ts-ignore TYPE NEEDS FIXING
+    (await assetAEstimatedOutputDiv.getProperty('textContent')).jsonValue()) as string
 
     return parseFloat(estimatedOutputString)
   }
@@ -75,15 +74,18 @@ export class RemoveLiquidityPage extends AppPage {
     }
 
     const reviewConfirmButton = await this.Page.waitForSelector(this.ReviewAndConfirmButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await reviewConfirmButton.click()
     await this.Page.waitForTimeout(500)
 
     const modalConfirmWithdrawButton = await this.Page.waitForSelector(this.ModalConfirmWithdrawButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await modalConfirmWithdrawButton.click()
 
     await this.confirmMetamaskTransaction()
 
     const backToPoolsButton = await this.Page.waitForSelector(this.BackToPoolsButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await backToPoolsButton.click()
 
     await this.blockingWait(5)
@@ -95,6 +97,7 @@ export class RemoveLiquidityPage extends AppPage {
     const withdrawTo = await this.Page.evaluate((el) => el.textContent, withdrawToElement)
 
     const outputSelector = await this.Page.waitForSelector(this.CheckOutputToWalletSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     const outputSelectorButton = (await outputSelector.$x('..'))[0]
 
     if (withdrawToWallet && withdrawTo.toLowerCase() !== 'wallet') {
@@ -107,6 +110,7 @@ export class RemoveLiquidityPage extends AppPage {
   public async setRemovePercent(percent: number): Promise<void> {
     await this.blockingWait(1, true)
     const percentSelectionButton = await this.Page.waitForSelector(this.RemovePercentSelector + percent.toString())
+    // @ts-ignore TYPE NEEDS FIXING
     await percentSelectionButton.click()
   }
 
@@ -114,6 +118,7 @@ export class RemoveLiquidityPage extends AppPage {
     await this.Page.waitForSelector(this.FixedRatioCheckboxSelector)
     const fixedRateCheckbox = await this.Page.$(this.FixedRatioCheckboxSelector)
 
+    // @ts-ignore TYPE NEEDS FIXING
     return fixedRateCheckbox
   }
 

--- a/test/e2e/pages/shared/CurrencySelectComponent.ts
+++ b/test/e2e/pages/shared/CurrencySelectComponent.ts
@@ -12,6 +12,7 @@ export class CurrencySelectComponent extends AppPageComponent {
 
     const tokenSelector = this.SelectTokenResultsSelector + tokenSymbol
     const tokenButton = await this.Page.waitForSelector(tokenSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await tokenButton.click()
   }
 }

--- a/test/e2e/pages/swap/SwapPage.ts
+++ b/test/e2e/pages/swap/SwapPage.ts
@@ -94,6 +94,7 @@ export class SwapPage extends AppPage {
     await this.blockingWait(1, true)
     await this.Page.waitForSelector(this.ExchangeRateButtonSelector)
     const rate = await this.Page.$(this.ExchangeRateButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     const rateText = (await (await rate.getProperty('textContent')).jsonValue()) as string
     return rateText
   }
@@ -108,6 +109,7 @@ export class SwapPage extends AppPage {
     }
 
     const inputTokenButton = await this.Page.waitForSelector(this.InTokenButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await inputTokenButton.click()
     await this.selectToken(tokenSymbol)
   }
@@ -121,6 +123,7 @@ export class SwapPage extends AppPage {
     }
 
     const outputTokenButton = await this.Page.waitForSelector(this.OutTokenButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await outputTokenButton.click()
     await this.selectToken(tokenSymbol)
   }
@@ -132,6 +135,7 @@ export class SwapPage extends AppPage {
   public async setAmountIn(inTokenAmount: string): Promise<void> {
     await this.Page.waitForTimeout(500)
     const tokenAmountInput = await this.Page.waitForSelector(this.TokenInputSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await tokenAmountInput.type(inTokenAmount)
   }
 
@@ -140,6 +144,7 @@ export class SwapPage extends AppPage {
     await this.Page.waitForSelector(this.TokenInputSelector)
     const tokenInput = await this.Page.$(this.TokenInputSelector)
 
+    // @ts-ignore TYPE NEEDS FIXING
     const inTokenAmount = (await (await tokenInput.getProperty('value')).jsonValue()) as string
     return inTokenAmount
   }
@@ -184,6 +189,7 @@ export class SwapPage extends AppPage {
     await this.blockingWait(1, true)
     await this.Page.waitForSelector(selector)
     const tokenButton = await this.Page.$(selector)
+    // @ts-ignore TYPE NEEDS FIXING
     const selectedToken = (await (await tokenButton.getProperty('textContent')).jsonValue()) as string
     return selectedToken
   }
@@ -191,9 +197,11 @@ export class SwapPage extends AppPage {
   public async getInputTokenBalance(): Promise<string> {
     await this.Page.waitForSelector(this.InTokenButtonSelector)
     const inputTokenLabel = await this.Page.$(this.InTokenButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     const inToken = (await (await inputTokenLabel.getProperty('textContent')).jsonValue()) as string
 
     const balanceLabel = await this.Page.waitForSelector(`#text-balance-${inToken}`)
+    // @ts-ignore TYPE NEEDS FIXING
     const inTokenBalance = (await (await balanceLabel.getProperty('textContent')).jsonValue()) as string
 
     return inTokenBalance
@@ -220,6 +228,7 @@ export class SwapPage extends AppPage {
       case SwapType.Wrap:
       case SwapType.Unwrap:
         const wrapButon = await this.Page.waitForSelector(this.WrapButtonSelector)
+        // @ts-ignore TYPE NEEDS FIXING
         await wrapButon.click()
 
         await this.blockingWait(1)
@@ -228,10 +237,12 @@ export class SwapPage extends AppPage {
       case SwapType.Normal:
       default:
         const swapButon = await this.Page.waitForSelector(this.SwapButtonSelector)
+        // @ts-ignore TYPE NEEDS FIXING
         await swapButon.click()
 
         await this.blockingWait(1)
         const confirmSwapButton = await this.Page.waitForSelector(this.ConfirmSwapButtonSelector)
+        // @ts-ignore TYPE NEEDS FIXING
         await confirmSwapButton.click()
         break
     }
@@ -248,9 +259,11 @@ export class SwapPage extends AppPage {
     await this.blockingWait(1, true)
 
     const TxSettingsButtonSelector = await this.Page.waitForSelector(this.TxSettingsButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await TxSettingsButtonSelector.click()
 
     const expertModeToggle = await this.Page.waitForSelector(this.ExpertModeToggleSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await expertModeToggle.click()
 
     const confirmExpertModeButton = await this.Page.$(this.ConfirmExpertModeSelector)
@@ -263,13 +276,17 @@ export class SwapPage extends AppPage {
     await this.blockingWait(1, true)
 
     const TxSettingsButtonSelector = await this.Page.waitForSelector(this.TxSettingsButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await TxSettingsButtonSelector.click()
 
     const slippageInput = await this.Page.waitForSelector(this.SlippageInputSelector)
 
+    // @ts-ignore TYPE NEEDS FIXING
     await slippageInput.click({ clickCount: 3 })
+    // @ts-ignore TYPE NEEDS FIXING
     await slippageInput.type(slippage)
 
+    // @ts-ignore TYPE NEEDS FIXING
     await TxSettingsButtonSelector.click()
   }
 
@@ -277,11 +294,13 @@ export class SwapPage extends AppPage {
     await this.blockingWait(1, true)
 
     const TxSettingsButtonSelector = await this.Page.waitForSelector(this.TxSettingsButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await TxSettingsButtonSelector.click()
 
     await this.Page.waitForSelector(this.SlippageInputSelector)
 
     const slippageInputTextBox = await this.Page.$(this.SlippageInputSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     const slippage = (await (await slippageInputTextBox.getProperty('value')).jsonValue()) as string
     return slippage
   }
@@ -291,9 +310,11 @@ export class SwapPage extends AppPage {
     await this.blockingWait(1, true)
 
     const addRecipientButton = await this.Page.waitForSelector(this.AddRecipientButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     addRecipientButton.click()
 
     const recipientInput = await this.Page.waitForSelector(this.RecipientInputSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await recipientInput.type(recipient)
   }
 
@@ -301,6 +322,7 @@ export class SwapPage extends AppPage {
     await this.blockingWait(1, true)
 
     let recipientInputBox: ElementHandle<Element>
+    // @ts-ignore TYPE NEEDS FIXING
     recipientInputBox = await this.Page.$(this.RecipientInputSelector)
 
     if (!recipientInputBox) {
@@ -314,6 +336,7 @@ export class SwapPage extends AppPage {
   public async clickSwitchCurrenciesButton(): Promise<void> {
     await this.blockingWait(1, true)
     const switchCurrenciesButton = await this.Page.waitForSelector(this.SwitchCurrenciesButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await switchCurrenciesButton.click()
     await this.blockingWait(1, true)
   }
@@ -324,6 +347,7 @@ export class SwapPage extends AppPage {
     await this.Page.waitForSelector(this.SwapButtonSelector)
     const swapButton = await this.Page.$(this.SwapButtonSelector)
 
+    // @ts-ignore TYPE NEEDS FIXING
     const swapButtonText = (await (await swapButton.getProperty('textContent')).jsonValue()) as string
     return swapButtonText
   }
@@ -339,6 +363,7 @@ export class SwapPage extends AppPage {
   public async clickInvertRateButton(): Promise<void> {
     await this.blockingWait(1, true)
     const invertRateButton = await this.Page.waitForSelector(this.ExchangeRateButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await invertRateButton.click()
   }
 
@@ -375,6 +400,7 @@ export class SwapPage extends AppPage {
   public async approveToken(): Promise<void> {
     await this.blockingWait(1, true)
     const approveButton = await this.Page.waitForSelector(this.ApproveButtonSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     await approveButton.click()
     await this.Metamask.confirmTransaction()
     await this.Metamask.page.waitForTimeout(1000)
@@ -396,6 +422,7 @@ export class SwapPage extends AppPage {
     await this.Page.waitForSelector(this.TradeTypeSelector)
 
     const tradeTypeInput = await this.Page.$(this.TradeTypeSelector)
+    // @ts-ignore TYPE NEEDS FIXING
     const tradeType = (await (await tradeTypeInput.getProperty('textContent')).jsonValue()) as string
     return tradeType.toLowerCase()
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false, // in local dev, this should be set to TRUE
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
@@ -48,8 +48,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "downlevelIteration": true,
-    "incremental": true,
-//    "strictNullChecks": true
+    "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig#strict

At the moment, we do not have strict mode enabled in our .tsconfig (https://github.com/sushiswap/sushiswap-interface/blob/master/tsconfig.json#L41). Unfortunately, that means we have a growing number of unsafe code lines (was 1200 violations in October, now it's at 1550) that have crept in silently. In many cases it's issues with nullChecking and implicitAny's. It's also highly likely there are bugs that has slipped past the compiler too.

Enabling strict mode will make us better developers and start making less buggy features. However, it is an impossible task to retroactively fix every one of the issues. This PR adds the in-your-face comment: `@ts-ignore TYPE NEEDS FIXING` to the lines with type violations. Hopefully, as we work on different features that touch files that have these comments, we can fix as we go.