### PR TITLE
refactor: slippage widget state management

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -28,9 +28,6 @@ export const PROTOCOL_MERKLE_ROOT =
 
 export const NetworkContextName = 'NETWORK'
 
-// default allowed slippage, in bips
-export const INITIAL_ALLOWED_SLIPPAGE = 50
-
 // 30 minutes, denominated in seconds
 export const DEFAULT_DEADLINE_FROM_NOW = 60 * 30
 

--- a/src/features/kashi/Borrow.tsx
+++ b/src/features/kashi/Borrow.tsx
@@ -2,7 +2,7 @@ import { defaultAbiCoder } from '@ethersproject/abi'
 import { BigNumber } from '@ethersproject/bignumber'
 import { hexConcat, hexlify } from '@ethersproject/bytes'
 import { AddressZero } from '@ethersproject/constants'
-import { Percent, SUSHISWAP_MULTISWAPPER_ADDRESS, WNATIVE } from '@sushiswap/core-sdk'
+import { SUSHISWAP_MULTISWAPPER_ADDRESS, WNATIVE } from '@sushiswap/core-sdk'
 import Button from 'app/components/Button'
 import KashiCooker from 'app/entities/KashiCooker'
 import { TransactionReview } from 'app/entities/TransactionReview'
@@ -14,7 +14,9 @@ import { computeRealizedLPFeePercent, warningSeverity } from 'app/functions/pric
 import { useCurrency } from 'app/hooks/Tokens'
 import { useV2TradeExactIn } from 'app/hooks/useV2Trades'
 import { useActiveWeb3React } from 'app/services/web3'
-import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
+import { useAppSelector } from 'app/state/hooks'
+import { selectSlippage } from 'app/state/slippage/slippageSlice'
+import { useExpertModeManager } from 'app/state/user/hooks'
 import { useETHBalances } from 'app/state/wallet/hooks'
 import React, { useMemo, useState } from 'react'
 
@@ -28,8 +30,6 @@ import WarningsView from './WarningsList'
 interface BorrowProps {
   pair: any
 }
-
-const DEFAULT_BORROW_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
 
 const DEFAULT_UPDATE_ORACLE = true
 
@@ -64,10 +64,7 @@ export default function Borrow({ pair }: BorrowProps) {
 
   const displayUpdateOracle = pair.currentExchangeRate.gt(0) ? updateOracle : true
 
-  // Swap
-  // const [allowedSlippage] = useUserSlippageTolerance(); // 10 = 0.1%
-
-  const allowedSlippage = useUserSlippageToleranceWithDefault(DEFAULT_BORROW_SLIPPAGE_TOLERANCE) // custom from users
+  const allowedSlippage = useAppSelector(selectSlippage)
 
   const parsedAmount = tryParseAmount(borrowValue, assetToken)
 

--- a/src/features/kashi/Repay.tsx
+++ b/src/features/kashi/Repay.tsx
@@ -14,7 +14,9 @@ import { computeRealizedLPFeePercent, warningSeverity } from 'app/functions/pric
 import { useCurrency } from 'app/hooks/Tokens'
 import { useV2TradeExactOut } from 'app/hooks/useV2Trades'
 import { useActiveWeb3React } from 'app/services/web3'
-import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
+import { useAppSelector } from 'app/state/hooks'
+import { selectSlippageWithDefault } from 'app/state/slippage/slippageSlice'
+import { useExpertModeManager } from 'app/state/user/hooks'
 import { useETHBalances } from 'app/state/wallet/hooks'
 import React, { useMemo, useState } from 'react'
 
@@ -89,9 +91,7 @@ export default function Repay({ pair }: RepayProps) {
 
   const displayRemoveValue = pinRemoveMax ? maxRemoveCollateral : removeValue
 
-  // Swap
-  // const [allowedSlippage] = useUserSlippageTolerance(); // 10 = 0.1%
-  const allowedSlippage = useUserSlippageToleranceWithDefault(DEFAULT_KASHI_REPAY_SLIPPAGE_TOLERANCE)
+  const allowedSlippage = useAppSelector(selectSlippageWithDefault(DEFAULT_KASHI_REPAY_SLIPPAGE_TOLERANCE))
 
   const parsedAmount = tryParseAmount(pair.currentUserBorrowAmount.string, assetToken)
 

--- a/src/features/onsen/PoolAddLiquidity.tsx
+++ b/src/features/onsen/PoolAddLiquidity.tsx
@@ -3,7 +3,7 @@ import { TransactionResponse } from '@ethersproject/providers'
 import { PlusIcon } from '@heroicons/react/solid'
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
-import { ChainId, CurrencyAmount, currencyEquals, NATIVE, Percent, WNATIVE } from '@sushiswap/core-sdk'
+import { ChainId, CurrencyAmount, currencyEquals, NATIVE, WNATIVE } from '@sushiswap/core-sdk'
 import AssetInput from 'app/components/AssetInput'
 import Button from 'app/components/Button'
 import { HeadlessUiModal } from 'app/components/Modal'
@@ -17,14 +17,14 @@ import { useRouterContract } from 'app/hooks/useContract'
 import useTransactionDeadline from 'app/hooks/useTransactionDeadline'
 import { useActiveWeb3React } from 'app/services/web3'
 import { USER_REJECTED_TX } from 'app/services/web3/WalletError'
+import { useAppSelector } from 'app/state/hooks'
 import { Field } from 'app/state/mint/actions'
 import { useDerivedMintInfo, useMintActionHandlers, useMintState } from 'app/state/mint/hooks'
+import { selectSlippage } from 'app/state/slippage/slippageSlice'
 import { useTransactionAdder } from 'app/state/transactions/hooks'
-import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
+import { useExpertModeManager } from 'app/state/user/hooks'
 import React, { useState } from 'react'
 import ReactGA from 'react-ga'
-
-const DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
 
 // @ts-ignore TYPE NEEDS FIXING
 const PoolDeposit = ({ currencyA, currencyB, header }) => {
@@ -35,7 +35,7 @@ const PoolDeposit = ({ currencyA, currencyB, header }) => {
   const [isExpertMode] = useExpertModeManager()
   const deadline = useTransactionDeadline() // custom from users settings
   const [attemptingTxn, setAttemptingTxn] = useState<boolean>(false) // clicked confirm
-  const allowedSlippage = useUserSlippageToleranceWithDefault(DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE) // custom from users
+  const allowedSlippage = useAppSelector(selectSlippage)
   const routerContract = useRouterContract()
   const addTransaction = useTransactionAdder()
 

--- a/src/features/onsen/PoolRemoveLiquidity.tsx
+++ b/src/features/onsen/PoolRemoveLiquidity.tsx
@@ -20,8 +20,9 @@ import { useActiveWeb3React } from 'app/services/web3'
 import { USER_REJECTED_TX } from 'app/services/web3/WalletError'
 import { Field } from 'app/state/burn/actions'
 import { useBurnActionHandlers, useBurnState, useDerivedBurnInfo } from 'app/state/burn/hooks'
+import { useAppSelector } from 'app/state/hooks'
+import { selectSlippageWithDefault } from 'app/state/slippage/slippageSlice'
 import { useTransactionAdder } from 'app/state/transactions/hooks'
-import { useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
 import React, { useCallback, useMemo, useState } from 'react'
 import ReactGA from 'react-ga'
 
@@ -50,7 +51,7 @@ const PoolWithdraw = ({ currencyA, currencyB, header }) => {
 
   // txn values
   const deadline = useTransactionDeadline()
-  const allowedSlippage = useUserSlippageToleranceWithDefault(DEFAULT_REMOVE_LIQUIDITY_SLIPPAGE_TOLERANCE)
+  const allowedSlippage = useAppSelector(selectSlippageWithDefault(DEFAULT_REMOVE_LIQUIDITY_SLIPPAGE_TOLERANCE))
 
   // pair contract
   const pairContract = usePairContract(pair?.liquidityToken?.address)

--- a/src/features/trident/add/useAddDetails.ts
+++ b/src/features/trident/add/useAddDetails.ts
@@ -4,12 +4,11 @@ import { useAddLiquidityDerivedCurrencyAmounts } from 'app/features/trident/add/
 import { usePoolContext } from 'app/features/trident/PoolContext'
 import { getPriceOfNewPool } from 'app/features/trident/utils'
 import { calculateSlippageAmount, toShareCurrencyAmount } from 'app/functions'
-import { useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
+import { useAppSelector } from 'app/state/hooks'
+import { selectSlippage } from 'app/state/slippage/slippageSlice'
 import { useMemo } from 'react'
 
-import { DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE } from '../constants'
-
-export const useAddDetails = (defaultSlippage: Percent = DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE) => {
+export const useAddDetails = () => {
   const {
     poolWithState,
     totalSupply,
@@ -20,7 +19,7 @@ export const useAddDetails = (defaultSlippage: Percent = DEFAULT_ADD_V2_SLIPPAGE
     liquidityValue: liquidityValueBefore,
     currencies,
   } = usePoolContext()
-  const slippage = useUserSlippageToleranceWithDefault(defaultSlippage)
+  const slippage = useAppSelector(selectSlippage)
   const parsedAmounts = useAddLiquidityDerivedCurrencyAmounts()
 
   // Returns the minimum SLP that will get minted given current input amounts

--- a/src/features/trident/constants.ts
+++ b/src/features/trident/constants.ts
@@ -1,10 +1,6 @@
-import { Percent } from '@sushiswap/core-sdk'
 import { PoolType } from '@sushiswap/tines'
 import { ChipColor } from 'app/components/Chip'
 import { classNames } from 'app/functions'
-
-export const DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
-export const DEFAULT_REMOVE_V2_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
 
 type PoolTypesInterface = Record<
   PoolType,

--- a/src/features/trident/migrate/SlippageWidget.tsx
+++ b/src/features/trident/migrate/SlippageWidget.tsx
@@ -1,22 +1,25 @@
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
-import { Percent } from '@sushiswap/core-sdk'
+import Button from 'app/components/Button'
 import QuestionHelper from 'app/components/QuestionHelper'
 import Typography from 'app/components/Typography'
-import { TRIDENT_MIGRATION_DEFAULT_SLIPPAGE } from 'app/features/trident/migrate/context/tridentMigrateAction'
-import { useSetUserSlippageTolerance, useUserSlippageTolerance } from 'app/state/user/hooks'
-import React, { useState } from 'react'
+import { classNames } from 'app/functions'
+import { useAppDispatch, useAppSelector } from 'app/state/hooks'
+import {
+  formatSlippageInput,
+  GLOBAL_DEFAULT_SLIPPAGE_PERCENT,
+  GLOBAL_DEFAULT_SLIPPAGE_STR,
+  setSlippageInput,
+  slippageSelectors,
+} from 'app/state/slippage/slippageSlice'
+import React from 'react'
 
-// TODO: Upcoming PR to synchronize with src/components/TransactionSettings/index.tsx
-// Should make logic into redux store so it can be repurposed
 export const SlippageWidget = () => {
   const { i18n } = useLingui()
-  const userSlippageTolerance = useUserSlippageTolerance()
-  const setSlippage = useSetUserSlippageTolerance()
+  const dispatch = useAppDispatch()
+  const { input, error, percent } = useAppSelector(slippageSelectors)
+  const slippageIsDefault = percent.equalTo(GLOBAL_DEFAULT_SLIPPAGE_PERCENT)
 
-  const [inputVal, setInputVal] = useState(
-    userSlippageTolerance === 'auto' ? TRIDENT_MIGRATION_DEFAULT_SLIPPAGE.toFixed(2) : userSlippageTolerance.toFixed(2)
-  )
   return (
     <div className="flex items-center md:self-start self-center gap-2">
       <div className="flex items-center">
@@ -28,20 +31,30 @@ export const SlippageWidget = () => {
           text={i18n._(t`Your transaction will revert if the price changes unfavorably by more than this percentage.`)}
         />
       </div>
-      <div className="border-low-emphesis border-2 h-[36px] flex items-center px-2 rounded bg-dark-1000/40 relative">
+      <div
+        className={classNames(
+          'border-2 h-[36px] flex items-center px-2 rounded bg-dark-1000/40 relative',
+          error ? 'border-red' : 'border-low-emphesis'
+        )}
+      >
         <input
           className="bg-transparent placeholder-low-emphesis min-w-0 font-bold w-16"
-          value={inputVal}
-          onChange={(e) => {
-            setInputVal(e.target.value)
-            try {
-              setSlippage(new Percent(Math.floor(parseFloat(e.target.value) * 100), 10_000))
-            } catch (e) {} // Ignore false inputs for now (upcoming PR to refactor)
-          }}
-          onBlur={() => {}}
+          value={input}
+          onChange={(e) => dispatch(setSlippageInput(e.target.value))}
+          onBlur={() =>
+            error ? dispatch(setSlippageInput(GLOBAL_DEFAULT_SLIPPAGE_STR)) : dispatch(formatSlippageInput())
+          }
         />
         <div className="text-low-emphesis">%</div>
       </div>
+      <Button
+        size="sm"
+        color={slippageIsDefault ? 'blue' : 'gray'}
+        variant="outlined"
+        onClick={() => dispatch(setSlippageInput(GLOBAL_DEFAULT_SLIPPAGE_STR))}
+      >
+        {i18n._(t`Auto`)}
+      </Button>
     </div>
   )
 }

--- a/src/features/trident/remove/useRemoveDetails.ts
+++ b/src/features/trident/remove/useRemoveDetails.ts
@@ -2,12 +2,11 @@ import { Currency, CurrencyAmount, Percent } from '@sushiswap/core-sdk'
 import { usePoolContext } from 'app/features/trident/PoolContext'
 import { useRemoveLiquidityDerivedSLPAmount } from 'app/features/trident/remove/useRemoveLiquidityDerivedState'
 import { calculateSlippageAmount, toAmountCurrencyAmount } from 'app/functions'
-import { useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
+import { useAppSelector } from 'app/state/hooks'
+import { selectSlippage } from 'app/state/slippage/slippageSlice'
 import { useCallback, useMemo } from 'react'
 
-import { DEFAULT_REMOVE_V2_SLIPPAGE_TOLERANCE } from '../constants'
-
-export const useRemoveDetails = (defaultSlippage: Percent = DEFAULT_REMOVE_V2_SLIPPAGE_TOLERANCE) => {
+export const useRemoveDetails = () => {
   const {
     poolWithState,
     totalSupply,
@@ -18,7 +17,7 @@ export const useRemoveDetails = (defaultSlippage: Percent = DEFAULT_REMOVE_V2_SL
     currencies,
   } = usePoolContext()
   const slpAmount = useRemoveLiquidityDerivedSLPAmount()
-  const slippage = useUserSlippageToleranceWithDefault(defaultSlippage)
+  const slippage = useAppSelector(selectSlippage)
 
   // Returns the resulting pool share after execution
   const poolShareAfter = useMemo(() => {

--- a/src/hooks/useSwapSlippageTollerence.ts
+++ b/src/hooks/useSwapSlippageTollerence.ts
@@ -1,6 +1,7 @@
 import { Currency, Percent, Trade, TradeType } from '@sushiswap/core-sdk'
 import { Trade as TridentTrade } from '@sushiswap/trident-sdk'
-import { useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
+import { useAppSelector } from 'app/state/hooks'
+import { selectSlippageWithDefault } from 'app/state/slippage/slippageSlice'
 import { useMemo } from 'react'
 
 const V2_SWAP_DEFAULT_SLIPPAGE = new Percent(50, 10_000) // .50%
@@ -13,5 +14,5 @@ export default function useSwapSlippageTolerance(
     if (!trade) return ONE_TENTHS_PERCENT
     return V2_SWAP_DEFAULT_SLIPPAGE
   }, [trade])
-  return useUserSlippageToleranceWithDefault(defaultSlippageTolerance)
+  return useAppSelector(selectSlippageWithDefault(defaultSlippageTolerance))
 }

--- a/src/pages/legacy/add/[[...tokens]].tsx
+++ b/src/pages/legacy/add/[[...tokens]].tsx
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
-import { Currency, CurrencyAmount, currencyEquals, Percent, WNATIVE } from '@sushiswap/core-sdk'
+import { Currency, CurrencyAmount, currencyEquals, WNATIVE } from '@sushiswap/core-sdk'
 import Alert from 'app/components/Alert'
 import Button from 'app/components/Button'
 import { AutoColumn } from 'app/components/Column'
@@ -32,17 +32,17 @@ import TransactionConfirmationModal, { ConfirmationModalContent } from 'app/moda
 import { useActiveWeb3React } from 'app/services/web3'
 import { USER_REJECTED_TX } from 'app/services/web3/WalletError'
 import { useWalletModalToggle } from 'app/state/application/hooks'
+import { useAppSelector } from 'app/state/hooks'
 import { Field } from 'app/state/mint/actions'
 import { useDerivedMintInfo, useMintActionHandlers, useMintState } from 'app/state/mint/hooks'
+import { selectSlippage } from 'app/state/slippage/slippageSlice'
 import { useTransactionAdder } from 'app/state/transactions/hooks'
-import { useExpertModeManager, useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
+import { useExpertModeManager } from 'app/state/user/hooks'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import React, { useCallback, useState } from 'react'
 import { Plus } from 'react-feather'
 import ReactGA from 'react-ga'
-
-const DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
 
 export default function Add() {
   const { i18n } = useLingui()
@@ -90,9 +90,7 @@ export default function Add() {
   // txn values
   const deadline = useTransactionDeadline() // custom from users settings
 
-  // const [allowedSlippage] = useUserSlippageTolerance(); // custom from users
-
-  const allowedSlippage = useUserSlippageToleranceWithDefault(DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE) // custom from users
+  const allowedSlippage = useAppSelector(selectSlippage)
 
   const [txHash, setTxHash] = useState<string>('')
 

--- a/src/pages/legacy/remove/[[...tokens]].tsx
+++ b/src/pages/legacy/remove/[[...tokens]].tsx
@@ -30,8 +30,9 @@ import { USER_REJECTED_TX } from 'app/services/web3/WalletError'
 import { useWalletModalToggle } from 'app/state/application/hooks'
 import { Field } from 'app/state/burn/actions'
 import { useBurnActionHandlers, useBurnState, useDerivedBurnInfo } from 'app/state/burn/hooks'
+import { useAppSelector } from 'app/state/hooks'
+import { selectSlippageWithDefault } from 'app/state/slippage/slippageSlice'
 import { useTransactionAdder } from 'app/state/transactions/hooks'
-import { useUserSlippageToleranceWithDefault } from 'app/state/user/hooks'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -69,7 +70,7 @@ export default function Remove() {
   // txn values
   const [txHash, setTxHash] = useState<string>('')
   const deadline = useTransactionDeadline()
-  const allowedSlippage = useUserSlippageToleranceWithDefault(DEFAULT_REMOVE_LIQUIDITY_SLIPPAGE_TOLERANCE)
+  const allowedSlippage = useAppSelector(selectSlippageWithDefault(DEFAULT_REMOVE_LIQUIDITY_SLIPPAGE_TOLERANCE))
 
   const formattedAmounts = {
     [Field.LIQUIDITY_PERCENT]: parsedAmounts[Field.LIQUIDITY_PERCENT].equalTo('0')

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -22,7 +22,7 @@ const migrations = {
   // },
 }
 
-const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists']
+const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists', 'slippage']
 
 const persistConfig = {
   key: 'root',

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -17,23 +17,25 @@ import limitOrder from './limit-order/reducer'
 import lists from './lists/reducer'
 import mint from './mint/reducer'
 import multicall from './multicall/reducer'
+import slippage from './slippage/slippageSlice'
 import swap from './swap/reducer'
 import transactions from './transactions/reducer'
 import user from './user/reducer'
 
 const reducer = combineReducers({
   application,
-  user,
-  transactions,
-  swap,
-  mint,
   burn,
-  multicall,
-  lists,
-  limitOrder,
+  user,
   create,
   inari,
+  limitOrder,
+  lists,
+  mint,
+  multicall,
   onsen,
+  slippage,
+  swap,
+  transactions,
   tridentSwap,
   tridentAdd,
   tridentRemove,

--- a/src/state/slippage/slippageSlice.test.ts
+++ b/src/state/slippage/slippageSlice.test.ts
@@ -1,0 +1,174 @@
+import { Percent } from '@sushiswap/core-sdk'
+import store, { AppState } from 'app/state'
+
+import {
+  formatSlippageInput,
+  GLOBAL_DEFAULT_SLIPPAGE_PERCENT,
+  GLOBAL_DEFAULT_SLIPPAGE_STR,
+  selectSlippage,
+  selectSlippageWithDefault,
+  setSlippageInput,
+  SlippageError,
+  slippageSelectors,
+  SlippageSliceState,
+} from './slippageSlice'
+
+describe('Slippage slice', () => {
+  let slippageState: SlippageSliceState
+
+  const getLatestState = () => {
+    slippageState = store.getState().slippage
+  }
+
+  beforeEach(() => {
+    slippageState = store.getState().slippage
+  })
+
+  afterEach(() => {
+    store.dispatch(setSlippageInput(GLOBAL_DEFAULT_SLIPPAGE_STR))
+  })
+
+  it('should return the correct initial state', () => {
+    expect(slippageState.input).toEqual(GLOBAL_DEFAULT_SLIPPAGE_STR)
+  })
+
+  it('should be able to change state', () => {
+    const testStr = '.135'
+    store.dispatch(setSlippageInput(testStr))
+    getLatestState()
+    expect(slippageState.input).toEqual(testStr)
+  })
+
+  describe('formatSlippageInput', () => {
+    it('should format correctly with valid inputs', () => {
+      store.dispatch(setSlippageInput('.3'))
+      store.dispatch(formatSlippageInput())
+      getLatestState()
+      expect(slippageState.input).toEqual('0.30')
+
+      store.dispatch(setSlippageInput('1.33'))
+      store.dispatch(formatSlippageInput())
+      getLatestState()
+      expect(slippageState.input).toEqual('1.33')
+
+      store.dispatch(setSlippageInput('5.655'))
+      store.dispatch(formatSlippageInput())
+      getLatestState()
+      expect(slippageState.input).toEqual('5.66')
+
+      store.dispatch(setSlippageInput('20'))
+      store.dispatch(formatSlippageInput())
+      getLatestState()
+      expect(slippageState.input).toEqual('20.00')
+    })
+
+    it('should not change the value if it is already invalid', () => {
+      store.dispatch(setSlippageInput('abcd'))
+      store.dispatch(formatSlippageInput())
+      getLatestState()
+      expect(slippageState.input).toEqual('abcd')
+
+      store.dispatch(setSlippageInput('.'))
+      store.dispatch(formatSlippageInput())
+      getLatestState()
+      expect(slippageState.input).toEqual('.')
+
+      store.dispatch(setSlippageInput(''))
+      store.dispatch(formatSlippageInput())
+      getLatestState()
+      expect(slippageState.input).toEqual('')
+    })
+  })
+
+  describe('slippageSelectors', () => {
+    describe('input', () => {
+      it('passes on input selector', () => {
+        store.dispatch(setSlippageInput('test'))
+        getLatestState()
+        const selectors = slippageSelectors({ slippage: slippageState } as AppState)
+        expect(selectors.input).toEqual('test')
+      })
+    })
+
+    describe('error state', () => {
+      it('handles invalid inputs', () => {
+        store.dispatch(setSlippageInput('invalid'))
+        getLatestState()
+        const { error } = slippageSelectors({ slippage: slippageState } as AppState)
+        expect(error).toEqual(SlippageError.INVALID_INPUT)
+      })
+
+      it('handles zero', () => {
+        store.dispatch(setSlippageInput('0'))
+        getLatestState()
+        const { error } = slippageSelectors({ slippage: slippageState } as AppState)
+        expect(error).toEqual(SlippageError.INVALID_INPUT)
+      })
+
+      it('handles negative inputs', () => {
+        store.dispatch(setSlippageInput('-1.3'))
+        getLatestState()
+        const { error } = slippageSelectors({ slippage: slippageState } as AppState)
+        expect(error).toEqual(SlippageError.INVALID_INPUT)
+      })
+
+      it('handles inputs too small', () => {
+        store.dispatch(setSlippageInput('.01'))
+        getLatestState()
+        const { error } = slippageSelectors({ slippage: slippageState } as AppState)
+        expect(error).toEqual(SlippageError.TOO_LOW)
+      })
+
+      it('handles inputs too large', () => {
+        store.dispatch(setSlippageInput('4'))
+        getLatestState()
+        const { error } = slippageSelectors({ slippage: slippageState } as AppState)
+        expect(error).toEqual(SlippageError.TOO_HIGH)
+      })
+    })
+
+    describe('percent', () => {
+      it('passes on slippage selector', () => {
+        store.dispatch(setSlippageInput('1'))
+        getLatestState()
+        const { percent } = slippageSelectors({ slippage: slippageState } as AppState)
+        expect(percent.equalTo(new Percent(1, 100))).toBeTruthy()
+      })
+    })
+  })
+
+  describe('selectSlippage', () => {
+    it('correctly parses input', () => {
+      store.dispatch(setSlippageInput('.2'))
+      getLatestState()
+      const slippage = selectSlippage({ slippage: slippageState } as AppState)
+      expect(slippage.equalTo(new Percent(2, 1000))).toBeTruthy()
+    })
+
+    it('correctly defaults to the global if input is not valid', () => {
+      store.dispatch(setSlippageInput('.'))
+      getLatestState()
+      const slippage = selectSlippage({ slippage: slippageState } as AppState)
+      expect(slippage.equalTo(GLOBAL_DEFAULT_SLIPPAGE_PERCENT)).toBeTruthy()
+    })
+  })
+
+  describe('selectSlippageWithDefault', () => {
+    it('goes to default if invalid input', () => {
+      const fallbackPercent = new Percent(4, 10_000)
+      store.dispatch(setSlippageInput('111'))
+      getLatestState()
+      const slippage = selectSlippageWithDefault(fallbackPercent)({ slippage: slippageState } as AppState)
+      expect(slippage.equalTo(fallbackPercent)).toBeTruthy()
+    })
+
+    it('parses correctly if valid input', () => {
+      const fallbackPercent = new Percent(4, 10_000)
+      store.dispatch(setSlippageInput('.2'))
+      getLatestState()
+      const slippage = selectSlippageWithDefault(fallbackPercent)({ slippage: slippageState } as AppState)
+      expect(slippage.equalTo(fallbackPercent)).toBeFalsy()
+      expect(slippage.equalTo(new Percent(2, 1000))).toBeTruthy()
+    })
+  })
+})

--- a/src/state/slippage/slippageSlice.ts
+++ b/src/state/slippage/slippageSlice.ts
@@ -1,0 +1,76 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { Percent } from '@sushiswap/core-sdk'
+import { AppState } from 'app/state'
+
+export const GLOBAL_DEFAULT_SLIPPAGE_PERCENT = new Percent(50, 10_000) // .5%
+export const GLOBAL_DEFAULT_SLIPPAGE_STR = GLOBAL_DEFAULT_SLIPPAGE_PERCENT.toFixed(2)
+
+export enum SlippageError {
+  TOO_LOW = 'TOO_LOW',
+  TOO_HIGH = 'TOO_HIGH',
+  INVALID_INPUT = 'INVALID_INPUT',
+}
+
+export interface SlippageSliceState {
+  input: string // User set value in the text box
+}
+
+const initialState: SlippageSliceState = {
+  input: GLOBAL_DEFAULT_SLIPPAGE_STR,
+}
+
+export const slippageSlice = createSlice({
+  name: 'slippage',
+  initialState,
+  reducers: {
+    setSlippageInput: (state, action: PayloadAction<string>) => {
+      state.input = action.payload
+    },
+    /* Takes a string like .3 and makes it 0.30 */
+    formatSlippageInput: (state) => {
+      const parsedInput = parseFloat(state.input)
+      if (isNaN(parsedInput)) return
+      state.input = parsedInput.toFixed(2)
+    },
+  },
+})
+
+export const { setSlippageInput, formatSlippageInput } = slippageSlice.actions
+
+const parseSlippageInput = (input: string): number => Math.floor(Number.parseFloat(input) * 100)
+const inputToPercent = (state: AppState) => new Percent(parseSlippageInput(state.slippage.input), 10_000)
+
+const selectSlippageInputError = (state: AppState): SlippageError | false => {
+  try {
+    const parsedInput = parseSlippageInput(state.slippage.input)
+    return !Number.isInteger(parsedInput) || parsedInput < 1
+      ? SlippageError.INVALID_INPUT
+      : inputToPercent(state).lessThan(new Percent(5, 10_000))
+      ? SlippageError.TOO_LOW
+      : inputToPercent(state).greaterThan(new Percent(1, 100))
+      ? SlippageError.TOO_HIGH
+      : false
+  } catch (e) {
+    return SlippageError.INVALID_INPUT
+  }
+}
+
+const selectSlippageInput = (state: AppState) => state.slippage.input
+
+export const selectSlippage = (state: AppState): Percent =>
+  selectSlippageInputError(state) ? GLOBAL_DEFAULT_SLIPPAGE_PERCENT : inputToPercent(state)
+
+export const selectSlippageWithDefault =
+  (fallbackDefault: Percent) =>
+  (state: AppState): Percent =>
+    selectSlippageInputError(state) ? fallbackDefault : inputToPercent(state)
+
+export const slippageSelectors = (state: AppState) => {
+  return {
+    input: selectSlippageInput(state),
+    percent: selectSlippage(state),
+    error: selectSlippageInputError(state),
+  }
+}
+
+export default slippageSlice.reducer

--- a/src/state/swap/reducer.test.ts
+++ b/src/state/swap/reducer.test.ts
@@ -12,7 +12,7 @@ describe('swap reducer', () => {
       [Field.INPUT]: { currencyId: '' },
       typedValue: '',
       independentField: Field.INPUT,
-      recipient: null,
+      recipient: undefined,
     })
   })
 

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -17,9 +17,6 @@ export const updateUserExpertMode = createAction<{ userExpertMode: boolean }>('u
 export const updateUserSingleHopOnly = createAction<{
   userSingleHopOnly: boolean
 }>('user/updateUserSingleHopOnly')
-export const updateUserSlippageTolerance = createAction<{
-  userSlippageTolerance: number | 'auto'
-}>('user/updateUserSlippageTolerance')
 export const updateUserDeadline = createAction<{ userDeadline: number }>('user/updateUserDeadline')
 export const addSerializedToken = createAction<{
   serializedToken: SerializedToken

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -8,10 +8,8 @@ import {
   computePairAddress,
   Currency,
   FACTORY_ADDRESS,
-  JSBI,
   KASHI_ADDRESS,
   Pair,
-  Percent,
   Token,
 } from '@sushiswap/core-sdk'
 import { CHAINLINK_PRICE_FEED_MAP } from 'app/config/oracles/chainlink'
@@ -36,7 +34,6 @@ import {
   updateUserDeadline,
   updateUserExpertMode,
   updateUserSingleHopOnly,
-  updateUserSlippageTolerance,
   updateUserUseOpenMev,
 } from './actions'
 
@@ -94,43 +91,7 @@ export function useUserSingleHopOnly(): [boolean, (newSingleHopOnly: boolean) =>
   return [singleHopOnly, setSingleHopOnly]
 }
 
-export function useSetUserSlippageTolerance(): (slippageTolerance: Percent | 'auto') => void {
-  const dispatch = useAppDispatch()
-
-  return useCallback(
-    (userSlippageTolerance: Percent | 'auto') => {
-      let value: 'auto' | number
-      try {
-        value =
-          userSlippageTolerance === 'auto' ? 'auto' : JSBI.toNumber(userSlippageTolerance.multiply(10_000).quotient)
-      } catch (error) {
-        value = 'auto'
-      }
-      dispatch(
-        updateUserSlippageTolerance({
-          userSlippageTolerance: value,
-        })
-      )
-    },
-    [dispatch]
-  )
-}
-
-/**
- * Return the user's slippage tolerance, from the redux store, and a function to update the slippage tolerance
- */
-export function useUserSlippageTolerance(): Percent | 'auto' {
-  const userSlippageTolerance = useAppSelector((state) => {
-    return state.user.userSlippageTolerance
-  })
-
-  return useMemo(
-    () => (userSlippageTolerance === 'auto' ? 'auto' : new Percent(userSlippageTolerance, 10_000)),
-    [userSlippageTolerance]
-  )
-}
-
-export function useUserTransactionTTL(): [number, (slippage: number) => void] {
+export function useUserTransactionTTL(): [number, (userDeadline: number) => void] {
   const dispatch = useAppDispatch()
   const userDeadline = useSelector<AppState, AppState['user']['userDeadline']>((state) => {
     return state.user.userDeadline
@@ -407,18 +368,6 @@ export function useTrackedTokenPairs(): [Token, Token][] {
 
     return Object.keys(keyed).map((key) => keyed[key])
   }, [combinedList])
-}
-
-/**
- * Same as above but replaces the auto with a default value
- * @param defaultSlippageTolerance the default value to replace auto with
- */
-export function useUserSlippageToleranceWithDefault(defaultSlippageTolerance: Percent): Percent {
-  const allowedSlippage = useUserSlippageTolerance()
-  return useMemo(
-    () => (allowedSlippage === 'auto' ? defaultSlippageTolerance : allowedSlippage),
-    [allowedSlippage, defaultSlippageTolerance]
-  )
 }
 
 /**

--- a/src/state/user/reducer.test.ts
+++ b/src/state/user/reducer.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_DEADLINE_FROM_NOW, INITIAL_ALLOWED_SLIPPAGE } from 'app/constants'
+import { DEFAULT_DEADLINE_FROM_NOW } from 'app/constants'
 import { updateVersion } from 'app/state/global/actions'
 import { createStore, Store } from 'redux'
 
@@ -28,7 +28,6 @@ describe('swap reducer', () => {
       } as any)
       store.dispatch(updateVersion())
       expect(store.getState().userDeadline).toEqual(DEFAULT_DEADLINE_FROM_NOW)
-      expect(store.getState().userSlippageTolerance).toEqual(INITIAL_ALLOWED_SLIPPAGE)
     })
   })
 })

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -1,5 +1,5 @@
 import { createReducer } from '@reduxjs/toolkit'
-import { DEFAULT_DEADLINE_FROM_NOW, INITIAL_ALLOWED_SLIPPAGE } from 'app/constants'
+import { DEFAULT_DEADLINE_FROM_NOW } from 'app/constants'
 import { updateVersion } from 'app/state/global/actions'
 
 import {
@@ -13,7 +13,6 @@ import {
   updateUserDeadline,
   updateUserExpertMode,
   updateUserSingleHopOnly,
-  updateUserSlippageTolerance,
   updateUserUseOpenMev,
 } from './actions'
 
@@ -26,9 +25,6 @@ export interface UserState {
   userExpertMode: boolean
 
   userSingleHopOnly: boolean // only allow swaps on direct pairs
-
-  // user defined slippage tolerance in bips, used in all txns
-  userSlippageTolerance: number | 'auto'
 
   // deadline set by user in minutes, used in all txns
   userDeadline: number
@@ -60,7 +56,6 @@ function pairKey(token0Address: string, token1Address: string) {
 export const initialState: UserState = {
   userExpertMode: false,
   userSingleHopOnly: false,
-  userSlippageTolerance: INITIAL_ALLOWED_SLIPPAGE,
   userDeadline: DEFAULT_DEADLINE_FROM_NOW,
   tokens: {},
   pairs: {},
@@ -72,12 +67,6 @@ export const initialState: UserState = {
 export default createReducer(initialState, (builder) =>
   builder
     .addCase(updateVersion, (state) => {
-      // slippage isnt being tracked in local storage, reset to default
-      // noinspection SuspiciousTypeOfGuard
-      if (typeof state.userSlippageTolerance !== 'number') {
-        state.userSlippageTolerance = INITIAL_ALLOWED_SLIPPAGE
-      }
-
       // deadline isnt being tracked in local storage, reset to default
       // noinspection SuspiciousTypeOfGuard
       if (typeof state.userDeadline !== 'number') {
@@ -89,10 +78,6 @@ export default createReducer(initialState, (builder) =>
 
     .addCase(updateUserExpertMode, (state, action) => {
       state.userExpertMode = action.payload.userExpertMode
-      state.timestamp = currentTimestamp()
-    })
-    .addCase(updateUserSlippageTolerance, (state, action) => {
-      state.userSlippageTolerance = action.payload.userSlippageTolerance
       state.timestamp = currentTimestamp()
     })
     .addCase(updateUserDeadline, (state, action) => {

--- a/test/e2e/addliquidity.test.ts
+++ b/test/e2e/addliquidity.test.ts
@@ -85,6 +85,7 @@ describe('Add Liquidity:', () => {
     const usdcWalletBalanceAfter = await addLiquidityPage.getAssetABalance(true)
 
     const usdcBalanceDiff = usdcWalletBalanceBefore - usdcWalletBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(usdcBalanceDiff, usdcDepositAmount, 1e-9)).toBe(true)
@@ -127,6 +128,7 @@ describe('Add Liquidity:', () => {
     const ethWalletBalanceAfter = await addLiquidityPage.getAssetBBalance(true)
 
     const ethBalanceDiff = ethWalletBalanceBefore - ethWalletBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(ethBalanceDiff, ethDepositAmount, 1e-9)).toBe(true)
@@ -169,6 +171,7 @@ describe('Add Liquidity:', () => {
     const ethBalanceAfter = await addLiquidityPage.getAssetBBalance(false)
 
     const ethBalanceDiff = ethBalanceBefore - ethBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(ethBalanceDiff, ethDepositAmount, 1e-9)).toBe(true)
@@ -219,6 +222,7 @@ describe('Add Liquidity:', () => {
 
     const assetABalanceDiff = assetAWalletBalanceBefore - assetAWalletBalanceAfter
     const assetBBalanceDiff = assetBWalletBalanceBefore - assetBWalletBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(assetABalanceDiff, assetADepositAmount, 1e-9)).toBe(true)
@@ -271,6 +275,7 @@ describe('Add Liquidity:', () => {
 
     const assetABalanceDiff = usdcBentoBalanceBefore - usdcBentoBalanceAfter
     const assetBBalanceDiff = ethWalletBalanceBefore - ethWalletBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(assetABalanceDiff, usdcDepositAmount, 1e-9)).toBe(true)
@@ -323,6 +328,7 @@ describe('Add Liquidity:', () => {
 
     const usdcBalanceDiff = usdcWalletBalanceBefore - usdcWalletBalanceAfter
     const ethBalanceDiff = ethBentoBalanceBefore - ethBentoBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(usdcBalanceDiff, usdcDepositAmount, 1e-9)).toBe(true)
@@ -377,6 +383,7 @@ describe('Add Liquidity:', () => {
 
     const usdcBalanceDiff = usdcBentoBalanceBefore - usdcBentoBalanceAfter
     const ethBalanceDiff = ethBentoBalanceBefore - ethBentoBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(usdcBalanceDiff, usdcDepositAmount, 1e-9)).toBe(true)
@@ -428,6 +435,7 @@ describe('Add Liquidity:', () => {
 
     const assetABalanceDiff = assetABentoBalanceBefore - assetABentoBalanceAfter
     const assetBBalanceDiff = assetBBentoBalanceBefore - assetBBentoBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(assetABalanceDiff, assetADepositAmount, 1e-9)).toBe(true)
@@ -482,6 +490,7 @@ describe('Add Liquidity:', () => {
 
     const usdcBalanceDiff = usdcWalletBalanceBefore - usdcWalletBalanceAfter
     const ethBalanceDiff = ethWalletBalanceBefore - ethWalletBalanceAfter
+    // @ts-ignore TYPE NEEDS FIXING
     const slpAmountDiff = positionAfterDeposit.slpAmount - positionBeforeDeposit.slpAmount
 
     expect(closeValues(usdcBalanceDiff, usdcDepositAmount, 1e-9)).toBe(true)


### PR DESCRIPTION
The need for more logic relating to the global slippage state prompted this PR. It seeks to pull out slippage into its own slice and pull some of the logic into the redux reducer and store instead of the component.

<img width="670" alt="Screen Shot 2022-02-04 at 4 50 42 PM" src="https://user-images.githubusercontent.com/16624263/152575523-ae4028f4-88f8-43e7-9c92-d91741dacb00.png">
