### PR TITLE
fix: copying wallet address from balances page

### DIFF
--- a/src/features/portfolio/HeaderDropdown.tsx
+++ b/src/features/portfolio/HeaderDropdown.tsx
@@ -48,7 +48,7 @@ const HeaderDropdown: FC<HeaderDropdownProps> = ({ account, hideAccount = false 
             </Link>
           )}
           {account && !hideAccount && (
-            <CopyHelper toCopy={shortenAddress(account)} className="opacity-100 text-primary">
+            <CopyHelper toCopy={account} className="opacity-100 text-primary">
               {shortenAddress(account)}
             </CopyHelper>
           )}


### PR DESCRIPTION
No longer copy shortened wallet address. Instead, copy the full address.

Fixes #595