### PR TITLE
fix: allow high/low slippage amounts

### DIFF
--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -104,7 +104,7 @@ const TransactionSettings: FC<TransactionSettingsProps> = ({ placeholderSlippage
                 value={slippageInput}
                 onChange={(e) => dispatch(setSlippageInput(e.target.value))}
                 onBlur={() =>
-                  slippageError
+                  slippageError === SlippageError.INVALID_INPUT
                     ? dispatch(setSlippageInput(GLOBAL_DEFAULT_SLIPPAGE_STR))
                     : dispatch(formatSlippageInput())
                 }

--- a/src/features/trident/migrate/SlippageWidget.tsx
+++ b/src/features/trident/migrate/SlippageWidget.tsx
@@ -10,6 +10,7 @@ import {
   GLOBAL_DEFAULT_SLIPPAGE_PERCENT,
   GLOBAL_DEFAULT_SLIPPAGE_STR,
   setSlippageInput,
+  SlippageError,
   slippageSelectors,
 } from 'app/state/slippage/slippageSlice'
 import React from 'react'
@@ -42,7 +43,9 @@ export const SlippageWidget = () => {
           value={input}
           onChange={(e) => dispatch(setSlippageInput(e.target.value))}
           onBlur={() =>
-            error ? dispatch(setSlippageInput(GLOBAL_DEFAULT_SLIPPAGE_STR)) : dispatch(formatSlippageInput())
+            error === SlippageError.INVALID_INPUT
+              ? dispatch(setSlippageInput(GLOBAL_DEFAULT_SLIPPAGE_STR))
+              : dispatch(formatSlippageInput())
           }
         />
         <div className="text-low-emphesis">%</div>

--- a/src/state/slippage/slippageSlice.ts
+++ b/src/state/slippage/slippageSlice.ts
@@ -43,7 +43,7 @@ const inputToPercent = (input: string) => new Percent(parseSlippageInput(input),
 const selectSlippageInputError = (state: AppState): SlippageError | false => {
   try {
     const parsedInput = parseSlippageInput(state.slippage.input)
-    return !Number.isInteger(parsedInput) || parsedInput < 1
+    return !Number.isInteger(parsedInput) || parsedInput < 1 || parsedInput > 5000
       ? SlippageError.INVALID_INPUT
       : inputToPercent(state.slippage.input).lessThan(new Percent(5, 10_000))
       ? SlippageError.TOO_LOW
@@ -58,14 +58,14 @@ const selectSlippageInputError = (state: AppState): SlippageError | false => {
 const selectSlippageInput = (state: AppState) => state.slippage.input
 
 export const selectSlippage = createSelector([selectSlippageInput, selectSlippageInputError], (input, error) => {
-  return error ? GLOBAL_DEFAULT_SLIPPAGE_PERCENT : inputToPercent(input)
+  return error === SlippageError.INVALID_INPUT ? GLOBAL_DEFAULT_SLIPPAGE_PERCENT : inputToPercent(input)
 })
 
 const fallbackParam = (state: AppState, fallbackDefault: Percent) => fallbackDefault
 const _composeSlippageWithDefault = createSelector(
   [selectSlippageInput, selectSlippageInputError, fallbackParam],
   (input, error, fallback) => {
-    return error ? fallback : inputToPercent(input)
+    return error === SlippageError.INVALID_INPUT ? fallback : inputToPercent(input)
   }
 )
 


### PR DESCRIPTION
Mistakenly assumed if slippage was too high or low that we should override with the default. This PR allows users to set high/slow slippage regardless.