### PR TITLE
feat: small kashi cards on portfolio page

### DIFF
--- a/src/features/kashi/hooks.ts
+++ b/src/features/kashi/hooks.ts
@@ -118,8 +118,13 @@ export function useKashiPairAddresses(): string[] {
   )
 }
 
-export function useKashiPairs(addresses: string[] = []) {
-  const { chainId, account } = useActiveWeb3React()
+export const useKashiPairs = (addresses: string[] = []) => {
+  const { account } = useActiveWeb3React()
+  return useKashiPairsForAccount(account, addresses)
+}
+
+export function useKashiPairsForAccount(account: string | null | undefined, addresses: string[] = []) {
+  const { chainId } = useActiveWeb3React()
 
   const boringHelperContract = useBoringHelperContract()
 

--- a/src/features/portfolio/AddressInputBox.tsx
+++ b/src/features/portfolio/AddressInputBox.tsx
@@ -1,0 +1,29 @@
+import { t } from '@lingui/macro'
+import { useLingui } from '@lingui/react'
+import Button from 'app/components/Button'
+import { isAddress } from 'app/functions'
+import React, { FC, useState } from 'react'
+
+interface AddressInputBoxProps {
+  onSubmit: (account: string) => void
+}
+
+export const AddressInputBox: FC<AddressInputBoxProps> = ({ onSubmit }) => {
+  const { i18n } = useLingui()
+
+  const [input, setInput] = useState('')
+  return (
+    <div className="flex gap-4">
+      <div className={'border-2 h-[36px] flex items-center px-2 rounded bg-dark-1000/40 relative border-low-emphesis'}>
+        <input
+          className="bg-transparent placeholder-low-emphesis min-w-0 font-bold w-96"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+      </div>
+      <Button size="sm" disabled={!isAddress(input)} onClick={() => onSubmit(input)}>
+        {i18n._(t`Submit`)}
+      </Button>
+    </div>
+  )
+}

--- a/src/features/portfolio/AssetBalances/bentoAndWallet/index.tsx
+++ b/src/features/portfolio/AssetBalances/bentoAndWallet/index.tsx
@@ -7,17 +7,17 @@ import { Assets } from 'app/features/portfolio/AssetBalances/types'
 import { setBalancesState } from 'app/features/portfolio/portfolioSlice'
 import { ActiveModal } from 'app/features/trident/types'
 import { useActiveWeb3React } from 'app/services/web3'
-import { useBentoBalancesV2 } from 'app/state/bentobox/hooks'
+import { useBentoBalancesV2ForAccount } from 'app/state/bentobox/hooks'
 import { useAppDispatch } from 'app/state/hooks'
 import { useAllTokenBalancesWithLoadingIndicator, useCurrencyBalance } from 'app/state/wallet/hooks'
-import React, { useCallback, useMemo } from 'react'
+import React, { FC, useCallback, useMemo } from 'react'
 
 import { useBasicTableConfig } from '../useBasicTableConfig'
 
-export const BentoBalances = () => {
+export const BentoBalances = ({ account }: { account: string }) => {
   const { i18n } = useLingui()
   const dispatch = useAppDispatch()
-  const { data: balances, loading } = useBentoBalancesV2()
+  const { data: balances, loading } = useBentoBalancesV2ForAccount(account)
   const assets = balances.reduce<Assets[]>((acc, el) => {
     if (el) acc.push({ asset: el })
     return acc
@@ -48,9 +48,9 @@ export const BentoBalances = () => {
   )
 }
 
-export const WalletBalances = () => {
+export const WalletBalances: FC<{ account: string }> = ({ account }) => {
   const { i18n } = useLingui()
-  const { chainId, account } = useActiveWeb3React()
+  const { chainId } = useActiveWeb3React()
   const dispatch = useAppDispatch()
   const { data: _balances, loading } = useAllTokenBalancesWithLoadingIndicator()
 

--- a/src/features/portfolio/AssetBalances/kashi/KashiCollateral.tsx
+++ b/src/features/portfolio/AssetBalances/kashi/KashiCollateral.tsx
@@ -1,13 +1,10 @@
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import { Currency, CurrencyAmount } from '@sushiswap/core-sdk'
-import Typography from 'app/components/Typography'
 import { Fraction } from 'app/entities'
 import { KashiMarket } from 'app/features/kashi/types'
-import AssetBalances from 'app/features/portfolio/AssetBalances/AssetBalances'
-import { useCollateralPositionAmounts } from 'app/features/portfolio/AssetBalances/kashi/hooks'
-import { useCollateralTableConfig } from 'app/features/portfolio/AssetBalances/kashi/useCollateralTableConfig'
-import { useRouter } from 'next/router'
+import { useKashiPositions } from 'app/features/portfolio/AssetBalances/kashi/hooks'
+import { CategorySum } from 'app/features/portfolio/CategorySum'
 import React from 'react'
 
 export interface CollateralData {
@@ -17,36 +14,19 @@ export interface CollateralData {
   pair: KashiMarket
 }
 
-const useGetCollateralTableData = (): CollateralData[] =>
-  useCollateralPositionAmounts().map((p) => ({
-    collateral: p.amount,
-    value: p.amount,
-    limit: p.pair.health.string as Fraction,
-    pair: p.pair,
-  }))
-
-export const KashiCollateral = () => {
+export const KashiCollateral = ({ account }: { account: string }) => {
   const { i18n } = useLingui()
-  const router = useRouter()
-
-  const data = useGetCollateralTableData()
-
-  const config = useCollateralTableConfig(data)
+  const { borrowed, collateral } = useKashiPositions(account)
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex gap-2 items-center">
-        <Typography weight={700} variant="lg" className="text-high-emphesis">
-          {i18n._(t`Kashi`)}
-        </Typography>
-        <Typography weight={700} variant="sm" className="text-low-emphesis">
-          {i18n._(t`(collateral on borrows)`)}
-        </Typography>
-      </div>
-      <AssetBalances
-        config={config}
-        onSelect={(row: { original: CollateralData }) => router.push(`/borrow/${row.original.pair.address}`)}
-      />
-    </div>
+    <CategorySum
+      title="Kashi"
+      subtitle={i18n._(t`(collateral minus borrowed)`)}
+      assetAmounts={collateral}
+      liabilityAmounts={borrowed}
+      route={`/borrow`}
+      // TODO: Change to new borrow page when ready
+      // route={`/portfolio/${account}/lend`}
+    />
   )
 }

--- a/src/features/portfolio/AssetBalances/kashi/KashiLent.tsx
+++ b/src/features/portfolio/AssetBalances/kashi/KashiLent.tsx
@@ -1,40 +1,25 @@
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
-import { Currency, CurrencyAmount } from '@sushiswap/core-sdk'
-import Typography from 'app/components/Typography'
-import { KashiMarket } from 'app/features/kashi/types'
-import AssetBalances from 'app/features/portfolio/AssetBalances/AssetBalances'
-import { useLendPositionAmounts } from 'app/features/portfolio/AssetBalances/kashi/hooks'
-import { useBasicTableConfig } from 'app/features/portfolio/AssetBalances/useBasicTableConfig'
-import { useRouter } from 'next/router'
+import { useKashiPositions } from 'app/features/portfolio/AssetBalances/kashi/hooks'
+import { CategorySum } from 'app/features/portfolio/CategorySum'
 import React from 'react'
 
-export const KashiLent = () => {
-  const { i18n } = useLingui()
-  const router = useRouter()
+interface KashiLentProps {
+  account: string
+}
 
-  const lentPositions = useLendPositionAmounts()
-  const { config } = useBasicTableConfig(
-    lentPositions.map((p) => ({ asset: p.amount, pair: p.pair })),
-    false
-  )
+export const KashiLent = ({ account }: KashiLentProps) => {
+  const { i18n } = useLingui()
+  const { lent } = useKashiPositions(account)
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex gap-2 items-center">
-        <Typography weight={700} variant="lg" className="text-high-emphesis">
-          {i18n._(t`Kashi`)}
-        </Typography>
-        <Typography weight={700} variant="sm" className="text-low-emphesis">
-          {i18n._(t`(lent assets)`)}
-        </Typography>
-      </div>
-      <AssetBalances
-        config={config}
-        onSelect={(row: { original: { asset: CurrencyAmount<Currency>; pair: KashiMarket } }) =>
-          router.push(`/lend/${row.original.pair.address}`)
-        }
-      />
-    </div>
+    <CategorySum
+      title="Kashi"
+      subtitle={i18n._(t`(lent assets)`)}
+      assetAmounts={lent}
+      route={`/lend`}
+      // TODO: Change to new lend page when ready
+      // route={`/portfolio/${account}/lend`}
+    />
   )
 }

--- a/src/features/portfolio/BalancesSum.tsx
+++ b/src/features/portfolio/BalancesSum.tsx
@@ -7,7 +7,7 @@ import SumUSDCValues from 'app/features/trident/SumUSDCValues'
 import { currencyFormatter } from 'app/functions'
 import { useTridentLiquidityPositions } from 'app/services/graph'
 import { useActiveWeb3React } from 'app/services/web3'
-import { useBentoBalancesV2 } from 'app/state/bentobox/hooks'
+import { useBentoBalancesV2ForAccount } from 'app/state/bentobox/hooks'
 import { useAllTokenBalancesWithLoadingIndicator, useCurrencyBalance } from 'app/state/wallet/hooks'
 import React, { FC, useMemo } from 'react'
 
@@ -41,8 +41,8 @@ export const LiquidityPositionsBalancesSum = () => {
   )
 }
 
-const useWalletBalances = () => {
-  const { chainId, account } = useActiveWeb3React()
+const useWalletBalances = (account: string) => {
+  const { chainId } = useActiveWeb3React()
   const { data: tokenBalances, loading } = useAllTokenBalancesWithLoadingIndicator()
   // @ts-ignore TYPE NEEDS FIXING
   const ethBalance = useCurrencyBalance(account ? account : undefined, chainId ? NATIVE[chainId] : undefined)
@@ -60,11 +60,11 @@ const useWalletBalances = () => {
   }, [tokenBalances, ethBalance, loading])
 }
 
-export const BalancesSum = () => {
+export const BalancesSum: FC<{ account: string }> = ({ account }) => {
   const { i18n } = useLingui()
-  const { data: walletBalances, loading: wLoading } = useWalletBalances()
-  const { data: bentoBalances, loading: bLoading } = useBentoBalancesV2()
-  const { borrowed, collateral, lent, kashiBalances } = useKashiPositions()
+  const { data: walletBalances, loading: wLoading } = useWalletBalances(account)
+  const { data: bentoBalances, loading: bLoading } = useBentoBalancesV2ForAccount(account)
+  const { borrowed, collateral, lent } = useKashiPositions(account)
 
   const allAssets = useMemo(() => {
     const combined = [...walletBalances, ...bentoBalances, ...collateral, ...lent]
@@ -88,12 +88,6 @@ export const BalancesSum = () => {
       <div className="flex gap-10">
         <_BalancesSum assetAmounts={walletBalances} label={i18n._(t`Wallet`)} loading={wLoading} />
         <_BalancesSum assetAmounts={bentoBalances} label={i18n._(t`BentoBox`)} loading={bLoading} />
-        <_BalancesSum
-          assetAmounts={kashiBalances}
-          liabilityAmounts={borrowed}
-          label={i18n._(t`Kashi`)}
-          loading={false}
-        />
         <div className="flex flex-col gap-1">
           <Typography variant="sm">{i18n._(t`Assets`)}</Typography>
           <Typography variant="lg">{allAssets.total}</Typography>

--- a/src/features/portfolio/CategorySum.tsx
+++ b/src/features/portfolio/CategorySum.tsx
@@ -1,0 +1,53 @@
+import { Currency, CurrencyAmount } from '@sushiswap/core-sdk'
+import Typography from 'app/components/Typography'
+import SumUSDCValues from 'app/features/trident/SumUSDCValues'
+import { currencyFormatter } from 'app/functions'
+import { useRouter } from 'next/router'
+import React from 'react'
+
+interface CategorySumProps {
+  title: string
+  subtitle?: string
+  assetAmounts: CurrencyAmount<Currency>[]
+  liabilityAmounts?: CurrencyAmount<Currency>[]
+  loading?: boolean
+  route: string
+}
+
+export const CategorySum = ({ title, subtitle, assetAmounts, liabilityAmounts, route }: CategorySumProps) => {
+  const router = useRouter()
+
+  return (
+    <SumUSDCValues amounts={assetAmounts}>
+      {({ amount: assetAmount }) => (
+        <SumUSDCValues amounts={liabilityAmounts}>
+          {({ amount: liabilityAmount }) => {
+            return (
+              <div onClick={() => router.push(route)}>
+                <div className="border border-dark-900 rounded flex justify-between p-4 hover:bg-dark-800 transition-colors hover:cursor-pointer">
+                  <div className="flex gap-2 items-center">
+                    <Typography weight={700} variant="lg" className="text-high-emphesis">
+                      {title}
+                    </Typography>
+                    {subtitle && (
+                      <Typography weight={700} variant="sm" className="text-low-emphesis">
+                        {subtitle}
+                      </Typography>
+                    )}
+                  </div>
+                  <Typography variant="lg" weight={400} className="text-high-emphesis">
+                    {assetAmount && liabilityAmount
+                      ? currencyFormatter.format(Number(assetAmount.subtract(liabilityAmount).toExact()))
+                      : assetAmount
+                      ? currencyFormatter.format(Number(assetAmount.toExact()))
+                      : '$0.00'}
+                  </Typography>
+                </div>
+              </div>
+            )
+          }}
+        </SumUSDCValues>
+      )}
+    </SumUSDCValues>
+  )
+}

--- a/src/features/portfolio/HeaderDropdown.tsx
+++ b/src/features/portfolio/HeaderDropdown.tsx
@@ -12,10 +12,11 @@ import Identicon from 'react-blockies'
 
 interface HeaderDropdownProps {
   hideAccount?: boolean
+  account: string
 }
 
-const HeaderDropdown: FC<HeaderDropdownProps> = ({ hideAccount = false }) => {
-  const { account, library, chainId } = useActiveWeb3React()
+const HeaderDropdown: FC<HeaderDropdownProps> = ({ account, hideAccount = false }) => {
+  const { library, chainId } = useActiveWeb3React()
   const [show, setShow] = useState<boolean>(false)
   const { ENSName } = useENSName(account ?? undefined)
 
@@ -53,7 +54,7 @@ const HeaderDropdown: FC<HeaderDropdownProps> = ({ hideAccount = false }) => {
           )}
         </div>
       </div>
-      <BalancesSum />
+      <BalancesSum account={account} />
     </>
   )
 }

--- a/src/features/portfolio/useAccountInUrl.ts
+++ b/src/features/portfolio/useAccountInUrl.ts
@@ -1,0 +1,14 @@
+import { isAddress } from 'app/functions'
+import { useRouter } from 'next/router'
+
+export const useAccountInUrl = (redirectPath: string): string | false => {
+  const router = useRouter()
+  const { account } = router.query
+
+  if (!account || typeof account !== 'string' || !isAddress(account)) {
+    router.replace(redirectPath)
+    return false
+  } else {
+    return account
+  }
+}

--- a/src/pages/portfolio/[account]/index.tsx
+++ b/src/pages/portfolio/[account]/index.tsx
@@ -1,0 +1,45 @@
+import { t } from '@lingui/macro'
+import { useLingui } from '@lingui/react'
+import ActionsModal from 'app/features/portfolio/ActionsModal'
+import { BentoBalances, WalletBalances } from 'app/features/portfolio/AssetBalances/bentoAndWallet'
+import { KashiCollateral } from 'app/features/portfolio/AssetBalances/kashi/KashiCollateral'
+import { KashiLent } from 'app/features/portfolio/AssetBalances/kashi/KashiLent'
+import HeaderDropdown from 'app/features/portfolio/HeaderDropdown'
+import { useAccountInUrl } from 'app/features/portfolio/useAccountInUrl'
+import TridentLayout, { TridentBody, TridentHeader } from 'app/layouts/Trident'
+import Head from 'next/head'
+import React from 'react'
+
+const Portfolio = () => {
+  const { i18n } = useLingui()
+
+  const account = useAccountInUrl('/portfolio')
+  if (!account) return
+
+  return (
+    <>
+      <Head>
+        <title>{i18n._(t`Portfolio`)} | Sushi</title>
+        <meta
+          key="description"
+          name="description"
+          content="Get a summary of all of the balances in your portfolio on Sushi."
+        />
+      </Head>
+      <TridentHeader pattern="bg-chevron">
+        <HeaderDropdown account={account} />
+      </TridentHeader>
+      <TridentBody className="flex flex-col gap-10 lg:grid grid-cols-2 lg:gap-4">
+        <KashiLent account={account} />
+        <KashiCollateral account={account} />
+        <WalletBalances account={account} />
+        <BentoBalances account={account} />
+      </TridentBody>
+      <ActionsModal />
+    </>
+  )
+}
+
+Portfolio.Layout = TridentLayout
+
+export default Portfolio

--- a/src/pages/portfolio/[account]/liquidity.tsx
+++ b/src/pages/portfolio/[account]/liquidity.tsx
@@ -1,14 +1,18 @@
 import { LiquidityPositionsBalances } from 'app/features/portfolio/AssetBalances/liquidityPositions'
 import { LiquidityPositionsBalancesSum } from 'app/features/portfolio/BalancesSum'
 import HeaderDropdown from 'app/features/portfolio/HeaderDropdown'
+import { useAccountInUrl } from 'app/features/portfolio/useAccountInUrl'
 import TridentLayout, { TridentBody, TridentHeader } from 'app/layouts/Trident'
 import React from 'react'
 
 const LiquidityPosition = () => {
+  const account = useAccountInUrl('/portfolio')
+  if (!account) return
+
   return (
     <>
       <TridentHeader pattern="bg-binary">
-        <HeaderDropdown />
+        <HeaderDropdown account={account} />
         <LiquidityPositionsBalancesSum />
       </TridentHeader>
       <TridentBody>

--- a/src/pages/portfolio/index.tsx
+++ b/src/pages/portfolio/index.tsx
@@ -1,16 +1,19 @@
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
-import ActionsModal from 'app/features/portfolio/ActionsModal'
-import { BentoBalances, WalletBalances } from 'app/features/portfolio/AssetBalances/bentoAndWallet'
-import { KashiCollateral } from 'app/features/portfolio/AssetBalances/kashi/KashiCollateral'
-import { KashiLent } from 'app/features/portfolio/AssetBalances/kashi/KashiLent'
-import HeaderDropdown from 'app/features/portfolio/HeaderDropdown'
-import TridentLayout, { TridentBody, TridentHeader } from 'app/layouts/Trident'
+import TridentLayout from 'app/layouts/Trident'
+import { useActiveWeb3React } from 'app/services/web3'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 import React from 'react'
 
 const Portfolio = () => {
   const { i18n } = useLingui()
+  const router = useRouter()
+  const { account } = useActiveWeb3React()
+
+  if (account) {
+    router.replace(`/portfolio/${account}`)
+  }
 
   return (
     <>
@@ -22,16 +25,17 @@ const Portfolio = () => {
           content="Get a summary of all of the balances in your portfolio on Sushi."
         />
       </Head>
-      <TridentHeader pattern="bg-chevron">
-        <HeaderDropdown />
-      </TridentHeader>
-      <TridentBody className="flex flex-col gap-10 lg:grid grid-cols-2 lg:gap-4">
-        <WalletBalances />
-        <BentoBalances />
-        <KashiCollateral />
-        <KashiLent />
-      </TridentBody>
-      <ActionsModal />
+      <div className="flex flex-col items-center gap-4 mt-32">
+        <div>{i18n._(t`Connect to your wallet ↗`)}</div>
+
+        {/*
+          At the moment, there is an RPC issue if you are not connected to your wallet.
+          As soon as this is resolved, this ⬇️ can be enabled.
+         */}
+        {/*<div>{i18n._(t`or`)}</div>*/}
+        {/*<div>{i18n._(t`Insert an address`)}</div>*/}
+        {/*<AddressInputBox onSubmit={(account: string) => router.replace(`/portfolio/${account}`)} />*/}
+      </div>
     </>
   )
 }

--- a/src/state/bentobox/hooks.ts
+++ b/src/state/bentobox/hooks.ts
@@ -1,4 +1,6 @@
+import { Web3Provider } from '@ethersproject/providers'
 import { CurrencyAmount, JSBI, Rebase, Token, ZERO } from '@sushiswap/core-sdk'
+import { Web3ReactContextInterface } from '@web3-react/core/dist/types'
 import { isAddress, toAmountCurrencyAmount } from 'app/functions'
 import { useAllTokens } from 'app/hooks/Tokens'
 import { useBentoBoxContract } from 'app/hooks/useContract'
@@ -35,7 +37,15 @@ export function useBentoMasterContractAllowed(masterContract?: string, user?: st
 }
 
 export const useBentoBalancesV2 = (tokenAddresses?: string[]): { data: CurrencyAmount<Token>[]; loading: boolean } => {
-  const { chainId, account } = useActiveWeb3React()
+  const { account } = useActiveWeb3React()
+  return useBentoBalancesV2ForAccount(account, tokenAddresses)
+}
+
+export const useBentoBalancesV2ForAccount = (
+  account: Web3ReactContextInterface<Web3Provider>['account'],
+  tokenAddresses?: string[]
+): { data: CurrencyAmount<Token>[]; loading: boolean } => {
+  const { chainId } = useActiveWeb3React()
   const {
     error,
     data,


### PR DESCRIPTION
Updates:
- Kashi now shortened summary (vs table). Links to borrow/lend page (will need to link to new pages in the future)
- Able to view portfolio page without a wallet connected
- New page if you go to /portfolio without wallet connected

In the ideal case, we could have a start page like this:
<img width="1499" alt="Screen Shot 2022-02-10 at 3 51 49 PM" src="https://user-images.githubusercontent.com/16624263/153432930-c1691389-3701-4f64-856e-98364f6ca3a0.png">

However, there is currently an RPC issue if you aren't connected
<img width="1461" alt="Screen Shot 2022-02-11 at 10 50 36 AM" src="https://user-images.githubusercontent.com/16624263/153571634-0a310238-2a54-4def-82d8-cedc3201aff8.png">

Therefore, this page is simplified until we can fix that issue:
<img width="1455" alt="Screen Shot 2022-02-11 at 10 55 30 AM" src="https://user-images.githubusercontent.com/16624263/153572151-3788dbd3-0040-4c9c-b02e-5df73d166f6d.png">

Then you land on the portfolio page with condensed kashi buttons that go to the Kashi lend/borrow pages:
<img width="1458" alt="Screen Shot 2022-02-10 at 3 51 02 PM" src="https://user-images.githubusercontent.com/16624263/153432946-4ad5d097-821c-4e46-aac2-529d05e8dfb1.png">

