### PR TITLE
fix: chain-id cookie sameSite attribute

### DIFF
--- a/src/pages/_middleware.tsx
+++ b/src/pages/_middleware.tsx
@@ -43,7 +43,8 @@ export function middleware(req: NextRequest) {
   // set the `cookie`
   res.cookie(
     'chain-id',
-    subdomain && subdomain in SUBDOMAIN_CHAIN_ID ? SUBDOMAIN_CHAIN_ID[subdomain] : DEFAULT_CHAIN_ID
+    subdomain && subdomain in SUBDOMAIN_CHAIN_ID ? SUBDOMAIN_CHAIN_ID[subdomain] : DEFAULT_CHAIN_ID,
+    { sameSite: 'none', secure: true }
   )
 
   // return the res


### PR DESCRIPTION
This PR allows "chain-id" cookie to be sent in all contexts.
SushiSwap doesn't load via iframe in some browsers w/o this fix.