### PR TITLE
feat: Allow EIP-747 for Coinbase wallets

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "web3-react-portis-connector": "npm:@web3-react/portis-connector@^6.0.9",
     "web3-react-types": "npm:@web3-react/types@^6.0.7",
     "web3-react-walletconnect-connector": "npm:@web3-react/walletconnect-connector@^7.0.2-alpha.0",
-    "web3-react-walletlink-connector": "npm:@web3-react/walletlink-connector@^6.2.13",
+    "web3-react-walletlink-connector": "npm:@web3-react/walletlink-connector@^6.2.14",
     "web3-utils": "^1.7.1",
     "yup": "^0.32.11",
     "zustand": "^3.7.2"

--- a/src/hooks/useAddToken.ts
+++ b/src/hooks/useAddToken.ts
@@ -3,18 +3,18 @@ import { getCurrencyLogoUrls } from 'app/components/CurrencyLogo/CurrencyLogo'
 import { useActiveWeb3React } from 'app/services/web3'
 import { useCallback, useState } from 'react'
 
-export default function useAddTokenToMetaMask(currencyToAdd: Currency | undefined): {
+export default function useAddToken(currencyToAdd: Currency | undefined): {
   addToken: () => void
   success: boolean | undefined
 } {
-  const { chainId, library } = useActiveWeb3React()
+  const { library } = useActiveWeb3React()
 
   const token: Token | undefined = currencyToAdd?.wrapped
 
   const [success, setSuccess] = useState<boolean | undefined>()
 
   const addToken = useCallback(() => {
-    if (library && library.provider.isMetaMask && library.provider.request && token) {
+    if (library && library.provider.request && token) {
       library.provider
         .request({
           method: 'wallet_watchAsset',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12928,7 +12928,7 @@ web3-provider-engine@16.0.1:
     "@web3-react/types" "^6.0.7"
     tiny-invariant "^1.0.6"
 
-"web3-react-walletlink-connector@npm:@web3-react/walletlink-connector@^6.2.13":
+"web3-react-walletlink-connector@npm:@web3-react/walletlink-connector@^6.2.14":
   version "6.2.14"
   resolved "https://registry.yarnpkg.com/@web3-react/walletlink-connector/-/walletlink-connector-6.2.14.tgz#4adf7b94de5d7018a9fc9e3b6009e78cd33d6e15"
   integrity sha512-F2v1Uu7Nhptt7AaUEJpz69+NVUJxyUfDEA5B/Vr1HkqAL1aJM5gv6B1m4M/VdXKLpmjZ9Kg6X0+VUEyAx1eQ4w==


### PR DESCRIPTION
This PR aims to allow sushiswap add tokens on Coinbase wallets using EIP-747 (wallet_watchAsset).

To achieve this, first this PR updates `@web3-react/walletlink-connector` to v^6.2.14, which [uses a newer version](https://github.com/NoahZinsmeister/web3-react/pull/475) of Coinbase SDK (that supports watchAsset requests).

It also refactors the `useAddTokenToMetaMask` hook, making it generic and able to be used for any provider (not just for MetaMask). 

The provider verifications were moved to the component code.