### PR TITLE
fix: support wETH withdraw for smart contract wallets

### DIFF
--- a/src/hooks/useWrapCallback.ts
+++ b/src/hooks/useWrapCallback.ts
@@ -81,7 +81,9 @@ export default function useWrapCallback(
           sufficientBalance && inputAmount
             ? async () => {
                 try {
-                  const txReceipt = await wethContract.withdraw(`0x${inputAmount.quotient.toString(16)}`)
+                  const txReceipt = await wethContract.withdraw(`0x${inputAmount.quotient.toString(16)}`, {
+                    gasLimit: 300000,
+                  })
                   addTransaction(txReceipt, {
                     summary: `Unwrap ${inputAmount.toSignificant(6)} ${WNATIVE[chainId].symbol} to ${
                       // @ts-ignore TYPE NEEDS FIXING


### PR DESCRIPTION
Fixes the withdraw wETH feature for smart contract wallets like Gnosis Safe. Without a gas limit, the `wethContract.withdraw` call fails with the error `Error: cannot estimate gas; transaction may fail or may require manual gas limit`.